### PR TITLE
Change keyType to type (do match DID Doc usage), add key owner.

### DIFF
--- a/lib/ld-key-pair.js
+++ b/lib/ld-key-pair.js
@@ -12,25 +12,40 @@ const DEFAULT_RSA_KEY_BITS = 2048;
 const DEFAULT_RSA_EXPONENT = 0x10001;
 
 class LDKeyPair {
+  /**
+   * @param options {object}
+   * @param [options.injector] {Injector}
+   *
+   * @param [options.type] {string} Key type,
+   *   for example 'Ed25519VerificationKey2018' or 'RsaVerificationKey2018'
+   *
+   * @param [options.publicKey] {string} base58-encoded or PEM-encoded
+   * @param [options.privateKey] {string}
+   * @param [options.passphrase=null] {string} For encrypting the private key
+   *
+   * @param [options.id] {string} Key id
+   * @param [options.owner] {string} DID or URI of owner
+   */
   constructor(options) {
     this.injector = options.injector || new Injector();
-    this.keyType = options.keyType;
+    this.type = options.type;
     this.publicKey = options.publicKey;
     this.privateKey = options.privateKey;
     this.passphrase = options.passphrase || null;
     this.id = options.id;
+    this.owner = options.owner;
   }
 
   /**
    * @param [options]
-   * @param [options.keyType]
+   * @param [options.type] {string} Key type
    * @param [options.injector]
    * @param [options.passphrase]
    *
    * @returns {Promise<LDKeyPair>}
    */
   static async generate(options) {
-    switch(options.keyType) {
+    switch(options.type) {
       case 'Ed25519VerificationKey2018':
         return Ed25519KeyPair.generate(options);
 
@@ -38,13 +53,13 @@ class LDKeyPair {
         return RSAKeyPair.generate(options);
 
       default:
-        throw new Error(`Unsupported Key Type: ${options.keyType}`);
+        throw new Error(`Unsupported Key Type: ${options.type}`);
     }
   }
 
   /**
    * @param data {object} Serialized LD key object
-   * @param data.keyType {string}
+   * @param [options.type] {string} Key type
    *
    * @param [options]
    * @param [options.injector]
@@ -53,7 +68,7 @@ class LDKeyPair {
    * @returns {Promise<LDKeyPair>}
    */
   static async from(data, options) {
-    switch(data.keyType) {
+    switch(data.type) {
       case 'Ed25519VerificationKey2018':
         return Ed25519KeyPair.from(data, options);
 
@@ -61,7 +76,7 @@ class LDKeyPair {
         return RSAKeyPair.from(data, options);
 
       default:
-        throw new Error(`Unsupported Key Type: ${options.keyType}`);
+        throw new Error(`Unsupported Key Type: ${options.type}`);
     }
   }
 
@@ -78,7 +93,7 @@ class LDKeyPair {
   publicNode({owner}) {
     const publicNode = {
       id: this.id,
-      type: this.keyType,
+      type: this.type,
       owner
     };
     this.addEncodedPublicKey(publicNode);
@@ -98,7 +113,7 @@ class Ed25519KeyPair extends LDKeyPair {
 
   /**
    * @param [options]
-   * @param [options.keyType]
+   * @param [options.type]
    * @param [options.injector]
    *
    * @returns {Promise<Ed25519KeyPair>}
@@ -118,11 +133,14 @@ class Ed25519KeyPair extends LDKeyPair {
   }
 
   static async from(data, options) {
+    const privateKey = data.privateKeyBase58 ||
+      (data.privateKey && data.privateKey.privateKeyBase58); // legacy privateDidDoc format
     const keyPair = new Ed25519KeyPair({
       publicKey: data.publicKeyBase58,
-      privateKey: data.privateKeyBase58,
+      privateKey: privateKey,
       id: data.id,
-      keyType: data.keyType,
+      type: data.type || data.keyType, // Todo: deprecate keyType usage
+      owner: data.owner,
       ...options
     });
 
@@ -133,7 +151,7 @@ class Ed25519KeyPair extends LDKeyPair {
   async export() {
     const keyNode = {
       id: this.id,
-      keyType: this.keyType,
+      type: this.type,
       publicKeyBase58: this.publicKey
     };
 
@@ -302,11 +320,14 @@ class RSAKeyPair extends LDKeyPair {
   }
 
   static async from(data, options) {
+    const privateKey = data.privateKeyPem ||
+      (data.privateKey && data.privateKey.privateKeyPem); // legacy privateDidDoc format
     const keys = new RSAKeyPair({
       publicKey: forge.pki.publicKeyFromPem(data.publicKeyPem),
-      privateKey: forge.pki.privateKeyFromPem(data.privateKeyPem),
+      privateKey: forge.pki.privateKeyFromPem(privateKey),
       id: data.id,
-      keyType: data.keyType,
+      type: data.type || data.keyType, // todo: deprecate keyType usage
+      owner: data.owner,
       ...options
     });
 
@@ -316,7 +337,7 @@ class RSAKeyPair extends LDKeyPair {
   async export() {
     const keyNode = {
       id: this.id,
-      keyType: this.keyType
+      type: this.type
     };
 
     this.addEncodedPublicKey(keyNode);

--- a/tests/ld-key-pair.spec.js
+++ b/tests/ld-key-pair.spec.js
@@ -11,16 +11,16 @@ const injector = {env: {nodejs: true}};
 
 describe('LDKeyPair', () => {
   describe('Ed25519KeyPair', () => {
-    const keyType = 'Ed25519VerificationKey2018';
+    const type = 'Ed25519VerificationKey2018';
 
     describe('export', () => {
       it('should export id, type and key material', async () => {
-        const keyPair = await LDKeyPair.generate({injector, keyType});
+        const keyPair = await LDKeyPair.generate({injector, type});
         keyPair.id = '#test-id';
         const exported = await keyPair.export();
 
         expect(exported.id).to.equal('#test-id');
-        expect(exported.keyType).to.equal(keyType);
+        expect(exported.type).to.equal(type);
         expect(exported).to.have.property('publicKeyBase58');
         expect(exported).to.have.property('privateKeyBase58');
       });
@@ -28,27 +28,73 @@ describe('LDKeyPair', () => {
 
     describe('static from', () => {
       it('should round-trip load exported keys', async () => {
-        const keyPair = await LDKeyPair.generate({injector, keyType});
+        const keyPair = await LDKeyPair.generate({injector, type});
         keyPair.id = '#test-id';
         const exported = await keyPair.export();
         const imported = await LDKeyPair.from(exported, {injector});
 
         expect(await imported.export()).to.eql(exported);
       });
+
+      it('should load from exported key storage format', async () => {
+        const keyData = JSON.parse(`{
+          "id": "did:v1:test:nym:z279nCCZVzxreYfLw3EtFLtBMSVVY2pA6uxKengriMCdG3DF#ocap-invoke-key-1",
+          "type": "Ed25519VerificationKey2018",
+          "owner": "did:v1:test:nym:z279nCCZVzxreYfLw3EtFLtBMSVVY2pA6uxKengriMCdG3DF",
+          "publicKeyBase58": "5U6TbzeAqQtSq9N52XPHFrF5cWwDPHk96uJvKshP4jN5",
+          "privateKeyBase58": "5hvHHCpocudyac6fT6jJCHe2WThQHsKYsjazkGV2L1Umwj5w9HtzcqoZ886yHJdHKbpC4W2qGhUMPbHNPpNDK6Dj"
+        }`);
+
+        const keyPair = await LDKeyPair.from(keyData, {injector});
+        expect(keyPair.type).to.equal('Ed25519VerificationKey2018');
+        expect(keyPair.id)
+          .to.equal('did:v1:test:nym:z279nCCZVzxreYfLw3EtFLtBMSVVY2pA6uxKengriMCdG3DF#ocap-invoke-key-1');
+        expect(keyPair.owner)
+          .to.equal('did:v1:test:nym:z279nCCZVzxreYfLw3EtFLtBMSVVY2pA6uxKengriMCdG3DF');
+
+        expect(keyPair.publicKey)
+          .to.equal('5U6TbzeAqQtSq9N52XPHFrF5cWwDPHk96uJvKshP4jN5');
+        expect(keyPair.privateKey)
+          .to.equal('5hvHHCpocudyac6fT6jJCHe2WThQHsKYsjazkGV2L1Umwj5w9HtzcqoZ886yHJdHKbpC4W2qGhUMPbHNPpNDK6Dj')
+      });
+
+      it('should load from legacy privateDidDocument format (ed25519)', async () => {
+        const keyData = JSON.parse(`{
+          "id": "did:v1:test:nym:z279nCCZVzxreYfLw3EtFLtBMSVVY2pA6uxKengriMCdG3DF#ocap-invoke-key-1",
+          "type": "Ed25519VerificationKey2018",
+          "owner": "did:v1:test:nym:z279nCCZVzxreYfLw3EtFLtBMSVVY2pA6uxKengriMCdG3DF",
+          "publicKeyBase58": "5U6TbzeAqQtSq9N52XPHFrF5cWwDPHk96uJvKshP4jN5",
+          "privateKey": {
+            "privateKeyBase58": "5hvHHCpocudyac6fT6jJCHe2WThQHsKYsjazkGV2L1Umwj5w9HtzcqoZ886yHJdHKbpC4W2qGhUMPbHNPpNDK6Dj"
+          }
+        }`);
+
+        const keyPair = await LDKeyPair.from(keyData, {injector});
+        expect(keyPair.type).to.equal('Ed25519VerificationKey2018');
+        expect(keyPair.id)
+          .to.equal('did:v1:test:nym:z279nCCZVzxreYfLw3EtFLtBMSVVY2pA6uxKengriMCdG3DF#ocap-invoke-key-1');
+        expect(keyPair.owner)
+          .to.equal('did:v1:test:nym:z279nCCZVzxreYfLw3EtFLtBMSVVY2pA6uxKengriMCdG3DF');
+
+        expect(keyPair.publicKey)
+          .to.equal('5U6TbzeAqQtSq9N52XPHFrF5cWwDPHk96uJvKshP4jN5');
+        expect(keyPair.privateKey)
+          .to.equal('5hvHHCpocudyac6fT6jJCHe2WThQHsKYsjazkGV2L1Umwj5w9HtzcqoZ886yHJdHKbpC4W2qGhUMPbHNPpNDK6Dj')
+      });
     });
   });
 
   describe('RSAKeyPair', () => {
-    const keyType = 'RsaVerificationKey2018';
+    const type = 'RsaVerificationKey2018';
 
     describe('export', () => {
       it('should export id, type and key material', async () => {
-        const keyPair = await LDKeyPair.generate({injector, keyType});
+        const keyPair = await LDKeyPair.generate({injector, type});
         keyPair.id = '#test-id';
         const exported = await keyPair.export();
 
         expect(exported.id).to.equal('#test-id');
-        expect(exported.keyType).to.equal(keyType);
+        expect(exported.type).to.equal(type);
         expect(exported).to.have.property('publicKeyPem');
         expect(exported).to.have.property('privateKeyPem');
       });
@@ -56,7 +102,7 @@ describe('LDKeyPair', () => {
 
     describe('static from', () => {
       it('should round-trip load exported keys', async () => {
-        const keyPair = await LDKeyPair.generate({injector, keyType});
+        const keyPair = await LDKeyPair.generate({injector, type});
         keyPair.id = '#test-id';
         const exported = await keyPair.export();
         const imported = await LDKeyPair.from(exported, {injector});


### PR DESCRIPTION
Rename `keyPair.keyType` property to `keyPair.type`, to match DID Doc usage.

This will enable convenient usage such as:

```js
const keyData = didDocument.capabilityInvocation[0].publicKey[0]
const keyPair = LDKeyPair.from(keyData);
```