### PR TITLE
Enhancement/jsdoc to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,13 @@ npm install
 
 ## Usage
 
-TBD
+See [LD Key Pair Documentation](/docs/LDKeyPair.md)
+
+See [ED 25519 Key Pair Documentation](/docs/Ed25519KeyPair.md)
+
+See [RSA Key Pair Documentation](/docs/RSAKeyPair.md)
+
+See [Type Documentation](/docs/index.md)
 
 ## Contribute
 

--- a/docs/Ed25519KeyPair.md
+++ b/docs/Ed25519KeyPair.md
@@ -1,0 +1,242 @@
+## Usage
+
+<a name="Ed25519KeyPair"></a>
+
+## Ed25519KeyPair
+**Kind**: global class  
+
+* [Ed25519KeyPair](#Ed25519KeyPair)
+    * [new Ed25519KeyPair(options)](#new_Ed25519KeyPair_new)
+    * _instance_
+        * [.publicKey](#Ed25519KeyPair+publicKey) ⇒ <code>string</code>
+        * [.privateKey](#Ed25519KeyPair+privateKey) ⇒ <code>string</code>
+        * [.signer()](#Ed25519KeyPair+signer) ⇒ <code>Object</code>
+        * [.verifier()](#Ed25519KeyPair+verifier) ⇒ <code>Object</code>
+        * [.addEncodedPublicKey(publicKeyNode)](#Ed25519KeyPair+addEncodedPublicKey) ⇒ <code>Object</code>
+        * [.addEncryptedPrivateKey(keyNode)](#Ed25519KeyPair+addEncryptedPrivateKey) ⇒ <code>Object</code>
+        * [.encrypt(privateKey, password)](#Ed25519KeyPair+encrypt) ⇒ <code>Promise.&lt;JWE&gt;</code>
+        * [.decrypt(jwe, password)](#Ed25519KeyPair+decrypt) ⇒ <code>Object</code>
+        * [.fingerprint()](#Ed25519KeyPair+fingerprint) ⇒ <code>string</code>
+        * [.verifyFingerprint(fingerprint)](#Ed25519KeyPair+verifyFingerprint) ⇒ <code>Object</code>
+    * _static_
+        * [.generate([options])](#Ed25519KeyPair.generate) ⇒ [<code>Promise.&lt;Ed25519KeyPair&gt;</code>](#Ed25519KeyPair)
+        * [.from(options)](#Ed25519KeyPair.from) ⇒ [<code>Ed25519KeyPair</code>](#Ed25519KeyPair)
+
+<a name="new_Ed25519KeyPair_new"></a>
+
+### new Ed25519KeyPair(options)
+An implementation of
+[Ed25519 Signature 2018](https://w3c-dvcg.github.io/lds-ed25519-2018/)
+for
+[jsonld-signatures.](https://github.com/digitalbazaar/jsonld-signatures)
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| options | <code>KeyPairOptions</code> | Base58 keys plus other options most follow [KeyPairOptions](./index.md#KeyPairOptions). |
+| options.publicKeyBase58 | <code>string</code> | Base58 encoded Public Key unencoded is 32-bytes. |
+| options.privateKeyBase58 | <code>string</code> | Base58 Private Key unencoded is 64-bytes. |
+
+**Example**  
+```js
+> const privateKey =
+  '3Mmk4UzTRJTEtxaKk61LxtgUxAa2Dg36jF6VogPtRiKvfpsQWKPCLesKSV182RMmvM'
+  + 'JKk6QErH3wgdHp8itkSSiF';
+> const options = {
+  publicKeyBase58: 'GycSSui454dpYRKiFdsQ5uaE8Gy3ac6dSMPcAoQsk8yq',
+  privateKeyBase58: privateKey
+};
+> const EDKey = new Ed25519KeyPair(options);
+> EDKey
+Ed25519KeyPair { ...
+```
+<a name="Ed25519KeyPair+publicKey"></a>
+
+### ed25519KeyPair.publicKey ⇒ <code>string</code>
+Returns the Base58 encoded public key.
+
+**Kind**: instance property of [<code>Ed25519KeyPair</code>](#Ed25519KeyPair)  
+**Implements**: <code>LDKeyPair#publicKey</code>  
+**Returns**: <code>string</code> - The Base58 encoded public key.  
+**Read only**: true  
+**See**: [publicKey](./LDKeyPair.md#publicKey)  
+<a name="Ed25519KeyPair+privateKey"></a>
+
+### ed25519KeyPair.privateKey ⇒ <code>string</code>
+Returns the Base58 encoded private key.
+
+**Kind**: instance property of [<code>Ed25519KeyPair</code>](#Ed25519KeyPair)  
+**Implements**: <code>LDKeyPair#privateKey</code>  
+**Returns**: <code>string</code> - The Base58 encoded private key.  
+**Read only**: true  
+**See**: [privateKey](./LDKeyPair.md#privateKey)  
+<a name="Ed25519KeyPair+signer"></a>
+
+### ed25519KeyPair.signer() ⇒ <code>Object</code>
+Returns a signer object for use with
+[jsonld-signatures](https://github.com/digitalbazaar/jsonld-signatures).
+
+**Kind**: instance method of [<code>Ed25519KeyPair</code>](#Ed25519KeyPair)  
+**Returns**: <code>Object</code> - A signer for the json-ld block.  
+**Example**  
+```js
+> const signer = keyPair.signer();
+> signer
+{ sign: [AsyncFunction: sign] }
+> signer.sign({data});
+```
+<a name="Ed25519KeyPair+verifier"></a>
+
+### ed25519KeyPair.verifier() ⇒ <code>Object</code>
+Returns a verifier object for use with
+[jsonld-signatures](https://github.com/digitalbazaar/jsonld-signatures).
+
+**Kind**: instance method of [<code>Ed25519KeyPair</code>](#Ed25519KeyPair)  
+**Returns**: <code>Object</code> - Used to verify jsonld-signatures.  
+**Example**  
+```js
+> const verifier = keyPair.verifier();
+> verifier
+{ verify: [AsyncFunction: verify] }
+> verifier.verify(key);
+```
+<a name="Ed25519KeyPair+addEncodedPublicKey"></a>
+
+### ed25519KeyPair.addEncodedPublicKey(publicKeyNode) ⇒ <code>Object</code>
+Adds a public key base to a public key node.
+
+**Kind**: instance method of [<code>Ed25519KeyPair</code>](#Ed25519KeyPair)  
+**Returns**: <code>Object</code> - A PublicKeyNode in a block.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| publicKeyNode | <code>Object</code> | The public key node in a jsonld-signature. |
+| publicKeyNode.publicKeyBase58 | <code>string</code> | Base58 Public Key for [jsonld-signatures](https://github.com/digitalbazaar/jsonld-signatures). |
+
+**Example**  
+```js
+> keyPair.addEncodedPublicKey({});
+{ publicKeyBase58: 'GycSSui454dpYRKiFdsQ5uaE8Gy3ac6dSMPcAoQsk8yq' }
+```
+<a name="Ed25519KeyPair+addEncryptedPrivateKey"></a>
+
+### ed25519KeyPair.addEncryptedPrivateKey(keyNode) ⇒ <code>Object</code>
+Adds an encrypted private key to the KeyPair.
+
+**Kind**: instance method of [<code>Ed25519KeyPair</code>](#Ed25519KeyPair)  
+**Returns**: <code>Object</code> - The keyNode with an encrypted private key attached.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| keyNode | <code>Object</code> | A plain object. |
+
+<a name="Ed25519KeyPair+encrypt"></a>
+
+### ed25519KeyPair.encrypt(privateKey, password) ⇒ <code>Promise.&lt;JWE&gt;</code>
+Produces a 32-byte encrypted key.
+
+**Kind**: instance method of [<code>Ed25519KeyPair</code>](#Ed25519KeyPair)  
+**Returns**: <code>Promise.&lt;JWE&gt;</code> - Produces JSON Web encrypted content.  
+**See**: [JWE](./index.md#JWE)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| privateKey | <code>string</code> | The base58 private key. |
+| password | <code>string</code> | The password. |
+
+**Example**  
+```js
+> const encryptedContent = await edKeyPair
+  .encrypt(privateKey, 'Test1244!');
+```
+<a name="Ed25519KeyPair+decrypt"></a>
+
+### ed25519KeyPair.decrypt(jwe, password) ⇒ <code>Object</code>
+Decrypts jwe content to a privateKey.
+
+**Kind**: instance method of [<code>Ed25519KeyPair</code>](#Ed25519KeyPair)  
+**Returns**: <code>Object</code> - A Base58 private key.  
+**See**: [JWE](./index.md#JWE)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| jwe | <code>JWE</code> | Encrypted content from a block. |
+| password | <code>string</code> | Password for the key used to sign the content. |
+
+<a name="Ed25519KeyPair+fingerprint"></a>
+
+### ed25519KeyPair.fingerprint() ⇒ <code>string</code>
+Generates and returns a multiformats encoded
+ed25519 public key fingerprint (for use with cryptonyms, for example).
+
+**Kind**: instance method of [<code>Ed25519KeyPair</code>](#Ed25519KeyPair)  
+**Returns**: <code>string</code> - A verifiable cryptographic signature.  
+**See**: https://github.com/multiformats/multicodec  
+**Example**  
+```js
+> edKeyPair.fingerprint();
+z6dfdsfdsfds3432423
+```
+<a name="Ed25519KeyPair+verifyFingerprint"></a>
+
+### ed25519KeyPair.verifyFingerprint(fingerprint) ⇒ <code>Object</code>
+Tests whether the fingerprint was
+generated from a given key pair.
+
+**Kind**: instance method of [<code>Ed25519KeyPair</code>](#Ed25519KeyPair)  
+**Returns**: <code>Object</code> - An object indicating valid is true or false.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| fingerprint | <code>string</code> | A Base58 public key. |
+
+**Example**  
+```js
+> edKeyPair.verifyFingerprint('z2S2Q6MkaFJewa');
+{valid: true};
+```
+<a name="Ed25519KeyPair.generate"></a>
+
+### Ed25519KeyPair.generate([options]) ⇒ [<code>Promise.&lt;Ed25519KeyPair&gt;</code>](#Ed25519KeyPair)
+Generates a KeyPair with an optional deterministic seed.
+
+**Kind**: static method of [<code>Ed25519KeyPair</code>](#Ed25519KeyPair)  
+**Returns**: [<code>Promise.&lt;Ed25519KeyPair&gt;</code>](#Ed25519KeyPair) - Generates a key pair.  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [options] | <code>KeyPairOptions</code> | <code>{}</code> | See LDKeyPair docstring for full list. |
+| [options.seed] | <code>Uint8Array</code> \| <code>Buffer</code> |  | a 32-byte array seed for a deterministic key. |
+
+**Example**  
+```js
+> const keyPair = await Ed25519KeyPair.generate();
+> keyPair
+Ed25519KeyPair { ...
+```
+<a name="Ed25519KeyPair.from"></a>
+
+### Ed25519KeyPair.from(options) ⇒ [<code>Ed25519KeyPair</code>](#Ed25519KeyPair)
+Creates an Ed25519 Key Pair from an existing private key.
+
+**Kind**: static method of [<code>Ed25519KeyPair</code>](#Ed25519KeyPair)  
+**Returns**: [<code>Ed25519KeyPair</code>](#Ed25519KeyPair) - An Ed25519 Key Pair.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| options | <code>Object</code> | Contains a private key. |
+| [options.privateKey] | <code>Object</code> | A private key object. |
+| [options.privateKeyBase58] | <code>string</code> | A Base58 Private key string. |
+
+**Example**  
+```js
+> const options = {
+  privateKeyBase58: privateKey
+};
+> const key = await Ed25519KeyPair.from(options);
+> key
+Ed25519KeyPair { ...
+```
+
+---
+Copyright (c) 2018-2019 Digital Bazaar, Inc. All rights reserved.

--- a/docs/LDKeyPair.md
+++ b/docs/LDKeyPair.md
@@ -1,0 +1,170 @@
+## Usage
+
+<a name="LDKeyPair"></a>
+
+## LDKeyPair
+The Abstract Base Class on which KeyPairs are based.
+
+**Kind**: global class  
+
+* [LDKeyPair](#LDKeyPair)
+    * [new LDKeyPair([options])](#new_LDKeyPair_new)
+    * _instance_
+        * *[.publicKey](#LDKeyPair+publicKey) ⇒ <code>string</code>*
+        * *[.privateKey](#LDKeyPair+privateKey) ⇒ <code>string</code>*
+        * [.publicNode([options])](#LDKeyPair+publicNode) ⇒ <code>Object</code>
+        * [.export()](#LDKeyPair+export) ⇒ <code>KeyPairOptions</code>
+    * _static_
+        * [.generate(options)](#LDKeyPair.generate) ⇒ [<code>Promise.&lt;LDKeyPair&gt;</code>](#LDKeyPair)
+        * [.from(options)](#LDKeyPair.from) ⇒ [<code>Promise.&lt;LDKeyPair&gt;</code>](#LDKeyPair)
+        * [.pbkdf2(password, salt, iterations, keySize)](#LDKeyPair.pbkdf2) ⇒ <code>Promise.&lt;Object&gt;</code>
+
+<a name="new_LDKeyPair_new"></a>
+
+### new LDKeyPair([options])
+Note: Actual key material
+(like `publicKeyBase58` for Ed25519 or
+`publicKeyPem` for RSA) is handled in the subclass.
+An LDKeyPair can encrypt private key material.
+
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [options] | <code>KeyPairOptions</code> | <code>{}</code> | See [KeyPairOptions](./index.md#KeyPairOptions). |
+| [options.passphrase] | <code>string</code> | <code>null</code> | For encrypting the private key. |
+| options.id | <code>string</code> |  | The Key id. |
+| options.controller | <code>string</code> |  | DID of the person/entity controlling   this key. |
+| [options.owner] | <code>string</code> |  | DID or URI of owner. DEPRECATED, use  `controller` instead. |
+
+**Example**  
+```js
+// LDKeyPair is an Abstract Class and should only
+// be used as a base class for other KeyPairs.
+```
+<a name="LDKeyPair+publicKey"></a>
+
+### *ldKeyPair.publicKey ⇒ <code>string</code>*
+**Kind**: instance abstract interface of [<code>LDKeyPair</code>](#LDKeyPair)  
+**Returns**: <code>string</code> - A public key.  
+**Throws**:
+
+- If not implemented by the subclass.
+
+**Read only**: true  
+<a name="LDKeyPair+privateKey"></a>
+
+### *ldKeyPair.privateKey ⇒ <code>string</code>*
+**Kind**: instance abstract interface of [<code>LDKeyPair</code>](#LDKeyPair)  
+**Returns**: <code>string</code> - A private key.  
+**Throws**:
+
+- If not implemented by the subclass.
+
+**Read only**: true  
+<a name="LDKeyPair+publicNode"></a>
+
+### ldKeyPair.publicNode([options]) ⇒ <code>Object</code>
+Contains the encryption type & public key for the KeyPair
+and other information that json-ld Signatures can use to form a proof.
+
+**Kind**: instance method of [<code>LDKeyPair</code>](#LDKeyPair)  
+**Returns**: <code>Object</code> - A public node with
+information used in verification methods by signatures.  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [options] | <code>Object</code> | <code>{}</code> | Needs either a controller or owner. |
+| [options.controller] | <code>string</code> | <code>&quot;this.controller&quot;</code> | DID of the person/entity controlling this key pair. |
+| [options.owner] | <code>string</code> | <code>&quot;this.owner&quot;</code> | DID of key owner. Deprecated term, use `controller`. |
+
+**Example**  
+```js
+> ldKeyPair.publicNode();
+{id: 'test-keypair-id', owner: 'did:uuid:example'}
+```
+<a name="LDKeyPair+export"></a>
+
+### ldKeyPair.export() ⇒ <code>KeyPairOptions</code>
+Exports the publicNode with an encrypted private key attached.
+
+**Kind**: instance method of [<code>LDKeyPair</code>](#LDKeyPair)  
+**Returns**: <code>KeyPairOptions</code> - A public node with encrypted private key.  
+**See**: [KeyPairOptions](./index.md#KeyPairOptions)  
+**Example**  
+```js
+> const withPrivateKey = await edKeyPair.export();
+```
+<a name="LDKeyPair.generate"></a>
+
+### LDKeyPair.generate(options) ⇒ [<code>Promise.&lt;LDKeyPair&gt;</code>](#LDKeyPair)
+Generates an LdKeyPair using SerializedLdKey options.
+
+**Kind**: static method of [<code>LDKeyPair</code>](#LDKeyPair)  
+**Returns**: [<code>Promise.&lt;LDKeyPair&gt;</code>](#LDKeyPair) - An LDKeyPair.  
+**Throws**:
+
+- Unsupported Key Type.
+
+**See**: [SerializedLdKey](./index.md#SerializedLdKey)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| options | <code>SerializedLdKey</code> | Options for generating the KeyPair. |
+
+**Example**  
+```js
+> const options = {
+   type: 'RsaVerificationKey2018',
+   passphrase: 'Test1234'
+ };
+> const keyPair = await LDKeyPair.generate(options);
+```
+<a name="LDKeyPair.from"></a>
+
+### LDKeyPair.from(options) ⇒ [<code>Promise.&lt;LDKeyPair&gt;</code>](#LDKeyPair)
+Generates a KeyPair from some options.
+
+**Kind**: static method of [<code>LDKeyPair</code>](#LDKeyPair)  
+**Returns**: [<code>Promise.&lt;LDKeyPair&gt;</code>](#LDKeyPair) - A LDKeyPair.  
+**Throws**:
+
+- Unsupported Key Type.
+
+**See**: [SerializedLdKey](./index.md#SerializedLdKey)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| options | <code>SerializedLdKey</code> | Will generate a key pair in multiple different formats. |
+
+**Example**  
+```js
+> const options = {
+   type: 'Ed25519VerificationKey2018',
+   passphrase: 'Test1234'
+  };
+> const edKeyPair = await LDKeyPair.from(options);
+```
+<a name="LDKeyPair.pbkdf2"></a>
+
+### LDKeyPair.pbkdf2(password, salt, iterations, keySize) ⇒ <code>Promise.&lt;Object&gt;</code>
+Generates a
+[pdkdf2](https://en.wikipedia.org/wiki/PBKDF2) key.
+
+**Kind**: static method of [<code>LDKeyPair</code>](#LDKeyPair)  
+**Returns**: <code>Promise.&lt;Object&gt;</code> - A promise that resolves to a pdkdf2 key.  
+**See**: https://github.com/digitalbazaar/forge#pkcs5  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| password | <code>string</code> | The password for the key. |
+| salt | <code>string</code> | Noise used to randomize the key. |
+| iterations | <code>number</code> | The number of times to run the algorithm. |
+| keySize | <code>number</code> | The byte length of the key. |
+
+**Example**  
+```js
+> const key = await LdKeyPair.pbkdf2('Test1234', salt, 10, 32);
+```
+
+---
+Copyright (c) 2018-2019 Digital Bazaar, Inc. All rights reserved.

--- a/docs/RSAKeyPair.md
+++ b/docs/RSAKeyPair.md
@@ -1,0 +1,229 @@
+## Usage
+
+## Classes
+
+<dl>
+<dt><a href="#RSAKeyPair">RSAKeyPair</a></dt>
+<dd></dd>
+</dl>
+
+## Constants
+
+<dl>
+<dt><a href="#DEFAULT_RSA_KEY_BITS">DEFAULT_RSA_KEY_BITS</a> : <code>number</code></dt>
+<dd></dd>
+<dt><a href="#DEFAULT_RSA_EXPONENT">DEFAULT_RSA_EXPONENT</a> : <code>number</code></dt>
+<dd></dd>
+</dl>
+
+<a name="RSAKeyPair"></a>
+
+## RSAKeyPair
+**Kind**: global class  
+
+* [RSAKeyPair](#RSAKeyPair)
+    * [new RSAKeyPair(options)](#new_RSAKeyPair_new)
+    * _instance_
+        * [.publicKey](#RSAKeyPair+publicKey) ⇒ <code>string</code>
+        * [.privateKey](#RSAKeyPair+privateKey) ⇒ <code>string</code>
+        * [.validateKeyParams()](#RSAKeyPair+validateKeyParams) ⇒ <code>undefined</code>
+        * [.addEncodedPublicKey(publicKeyNode)](#RSAKeyPair+addEncodedPublicKey) ⇒ <code>KeyPairOptions</code>
+        * [.addEncryptedPrivateKey(keyNode)](#RSAKeyPair+addEncryptedPrivateKey) ⇒ <code>KeyPairOptions</code>
+        * [.fingerprint()](#RSAKeyPair+fingerprint) ⇒ <code>string</code>
+        * [.signer()](#RSAKeyPair+signer) ⇒ <code>Object</code>
+        * [.verifier()](#RSAKeyPair+verifier) ⇒ <code>Object</code>
+    * _static_
+        * [.generate([options])](#RSAKeyPair.generate) ⇒ [<code>Promise.&lt;RSAKeyPair&gt;</code>](#RSAKeyPair)
+        * [.from(options)](#RSAKeyPair.from) ⇒ [<code>RSAKeyPair</code>](#RSAKeyPair)
+
+<a name="new_RSAKeyPair_new"></a>
+
+### new RSAKeyPair(options)
+An implementation of
+[RSA encryption](https://simple.wikipedia.org/wiki/RSA_algorithm)
+for
+[jsonld-signatures](https://github.com/digitalbazaar/jsonld-signatures).
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| options | <code>KeyPairOptions</code> | Keys must be in RSA format other options must follow [KeyPairOptions](./index.md#KeyPairOptions). |
+| options.publicKeyPem | <code>string</code> | Public Key for Signatures. |
+| options.privateKeyPem | <code>string</code> | Your Confidential key for signing. |
+
+**Example**  
+```js
+> const options = {
+   privateKeyPem: 'testPrivateKey',
+   publicKeyPem: 'testPublicKey'
+ };
+> const RSAKey = new RSAKeyPair(options);
+```
+<a name="RSAKeyPair+publicKey"></a>
+
+### rsaKeyPair.publicKey ⇒ <code>string</code>
+Returns the public key.
+
+**Kind**: instance property of [<code>RSAKeyPair</code>](#RSAKeyPair)  
+**Implements**: <code>LDKeyPair#publicKey</code>  
+**Returns**: <code>string</code> - The public key.  
+**Read only**: true  
+**See**: [publicKey](./LDKeyPair.md#publicKey)  
+<a name="RSAKeyPair+privateKey"></a>
+
+### rsaKeyPair.privateKey ⇒ <code>string</code>
+Returns the private key.
+
+**Kind**: instance property of [<code>RSAKeyPair</code>](#RSAKeyPair)  
+**Implements**: <code>LDKeyPair#privateKey</code>  
+**Returns**: <code>string</code> - The private key.  
+**Read only**: true  
+**See**: [privateKey](./LDKeyPair.md#privateKey)  
+<a name="RSAKeyPair+validateKeyParams"></a>
+
+### rsaKeyPair.validateKeyParams() ⇒ <code>undefined</code>
+Validates this key.
+
+**Kind**: instance method of [<code>RSAKeyPair</code>](#RSAKeyPair)  
+**Returns**: <code>undefined</code> - If it does not throw then the key is valid.  
+**Throws**:
+
+- Invalid RSA keyBit length
+- Invalid RSA exponent
+
+**Example**  
+```js
+> rsaKeyPair.validateKeyParams();
+undefined
+```
+<a name="RSAKeyPair+addEncodedPublicKey"></a>
+
+### rsaKeyPair.addEncodedPublicKey(publicKeyNode) ⇒ <code>KeyPairOptions</code>
+Adds this KeyPair's publicKeyPem to a public node.
+
+**Kind**: instance method of [<code>RSAKeyPair</code>](#RSAKeyPair)  
+**Returns**: <code>KeyPairOptions</code> - A public node with a publicKeyPem set.  
+**See**: [KeyPairOptions](./index.md#KeyPairOptions)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| publicKeyNode | <code>KeyPairOptions</code> | A Node with out a publicKeyPem set. |
+
+**Example**  
+```js
+> rsaKeyPair.addEncodedPublicKey({id: 'testnode'});
+{ publicKeyPem: 'testPublicKey' }
+```
+<a name="RSAKeyPair+addEncryptedPrivateKey"></a>
+
+### rsaKeyPair.addEncryptedPrivateKey(keyNode) ⇒ <code>KeyPairOptions</code>
+Adds this KeyPair's privateKeyPem to a public node.
+
+**Kind**: instance method of [<code>RSAKeyPair</code>](#RSAKeyPair)  
+**Returns**: <code>KeyPairOptions</code> - A public node with a privateKeyPem set.  
+**See**: [KeyPairOptions](./index.md#KeyPairOptions)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| keyNode | <code>KeyPairOptions</code> | A Node with out a publicKeyPem set. |
+
+**Example**  
+```js
+> rsaKeyPair.addEncryptedPrivateKey({id: 'testnode'});
+{ privateKeyPem: 'testPrivateKey' }
+```
+<a name="RSAKeyPair+fingerprint"></a>
+
+### rsaKeyPair.fingerprint() ⇒ <code>string</code>
+Generates and returns a multiformats
+encoded RSA public key fingerprint (for use with cryptonyms, for example).
+
+**Kind**: instance method of [<code>RSAKeyPair</code>](#RSAKeyPair)  
+**Returns**: <code>string</code> - An RSA fingerprint.  
+**Example**  
+```js
+> rsaKeyPair.fingerprint();
+3423dfdsf3432sdfdsds
+```
+<a name="RSAKeyPair+signer"></a>
+
+### rsaKeyPair.signer() ⇒ <code>Object</code>
+Returns a signer object with an async sign function for use by
+[jsonld-signatures](https://github.com/digitalbazaar/jsonld-signatures)
+to sign content in a signature.
+
+**Kind**: instance method of [<code>RSAKeyPair</code>](#RSAKeyPair)  
+**Returns**: <code>Object</code> - An RSA Signer Function for a single key.
+for a single Private Key.  
+**Example**  
+```js
+> const signer = rsaKeyPair.signer();
+> signer.sign({data});
+```
+<a name="RSAKeyPair+verifier"></a>
+
+### rsaKeyPair.verifier() ⇒ <code>Object</code>
+Returns a verifier object with an async
+function verify for use with
+[jsonld-signatures](https://github.com/digitalbazaar/jsonld-signatures).
+
+**Kind**: instance method of [<code>RSAKeyPair</code>](#RSAKeyPair)  
+**Returns**: <code>Object</code> - An RSA Verifier Function for a single key.  
+**Example**  
+```js
+> const verifier = rsaKeyPair.verifier();
+> const valid = await verifier.verify({data, signature});
+```
+<a name="RSAKeyPair.generate"></a>
+
+### RSAKeyPair.generate([options]) ⇒ [<code>Promise.&lt;RSAKeyPair&gt;</code>](#RSAKeyPair)
+Generates an RSA KeyPair using the RSA Defaults.
+
+**Kind**: static method of [<code>RSAKeyPair</code>](#RSAKeyPair)  
+**Returns**: [<code>Promise.&lt;RSAKeyPair&gt;</code>](#RSAKeyPair) - A Default encrypted RSA KeyPair.  
+**See**: [KeyPairOptions](./index.md#KeyPairOptions)  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [options] | <code>KeyPairOptions</code> | <code>{}</code> | See LDKeyPair docstring for full list. |
+
+**Example**  
+```js
+> const keyPair = await RSAKeyPair.generate();
+> keyPair
+RSAKeyPair { ...
+```
+<a name="RSAKeyPair.from"></a>
+
+### RSAKeyPair.from(options) ⇒ [<code>RSAKeyPair</code>](#RSAKeyPair)
+Creates a RSA Key Pair from an existing private key.
+
+**Kind**: static method of [<code>RSAKeyPair</code>](#RSAKeyPair)  
+**Returns**: [<code>RSAKeyPair</code>](#RSAKeyPair) - An RSA Key Pair.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| options | <code>Object</code> | Contains a private key. |
+| [options.privateKey] | <code>Object</code> | A private key. |
+| [options.privateKeyPem] | <code>string</code> | An RSA Private key. |
+
+**Example**  
+```js
+> const options = {
+   privateKeyPem: 'testkeypem'
+ };
+> const key = await RSAKeyPair.from(options);
+```
+<a name="DEFAULT_RSA_KEY_BITS"></a>
+
+## DEFAULT\_RSA\_KEY\_BITS : <code>number</code>
+**Kind**: global constant  
+**Default**: <code>2048</code>  
+<a name="DEFAULT_RSA_EXPONENT"></a>
+
+## DEFAULT\_RSA\_EXPONENT : <code>number</code>
+**Kind**: global constant  
+**Default**: <code>65537</code>  
+
+---
+Copyright (c) 2018-2019 Digital Bazaar, Inc. All rights reserved.

--- a/docs/generate.js
+++ b/docs/generate.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2018-2019 Digital Bazaar, Inc. All rights reserved.
+ */
+const jsdoc2md = require('jsdoc-to-markdown');
+const fs = require('fs');
+
+const template = fs.readFileSync('./docs/template.hbs', 'utf-8');
+const opFactory = file => ({template, files: `./lib/${file}`});
+
+// we only generate docs for files which end with keypair or index.
+const docs = /(keypair|index).js/i;
+const files = fs.readdirSync('./lib/', {withFileTypes: true})
+  .filter(p => docs.test(p));
+files.forEach(filePath => {
+  const options = opFactory(filePath);
+  const doc = jsdoc2md.renderSync(options);
+  // if the doc is smaller than the template there was
+  // no actual content inserted into main.
+  if(!doc || doc.length < template.length) {
+    return false;
+  }
+  const docFileName = './docs/' + filePath.replace(/.js/, '.md');
+  fs.writeFileSync(docFileName, doc);
+});

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,78 @@
+## Usage
+
+## Typedefs
+
+<dl>
+<dt><a href="#JWE">JWE</a> : <code>Object</code></dt>
+<dd><p><a href="https://tools.ietf.org/html/rfc7516">JSON Web encryption</a></p>
+</dd>
+<dt><a href="#PSS">PSS</a> : <code>Object</code></dt>
+<dd><p>PSS Object</p>
+</dd>
+<dt><a href="#KeyPairOptions">KeyPairOptions</a> : <code>Object</code></dt>
+<dd><p>KeyPair Options.</p>
+</dd>
+<dt><a href="#SerializedLdKey">SerializedLdKey</a> : <code>Object</code></dt>
+<dd><p>Serialized LD Key.</p>
+</dd>
+</dl>
+
+<a name="JWE"></a>
+
+## JWE : <code>Object</code>
+[JSON Web encryption](https://tools.ietf.org/html/rfc7516)
+
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| unprotected | <code>string</code> | A header for the jwe. |
+| iv | <code>string</code> | A base64 url. |
+| ciphertext | <code>string</code> | A base64 url. |
+| tag | <code>string</code> | A base64 url. |
+
+<a name="PSS"></a>
+
+## PSS : <code>Object</code>
+PSS Object
+
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| encode | <code>function</code> | 
+| verify | <code>function</code> | 
+
+<a name="KeyPairOptions"></a>
+
+## KeyPairOptions : <code>Object</code>
+KeyPair Options.
+
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| passphrase | <code>string</code> | For encrypting the private key. |
+| id | <code>string</code> | Key Id. |
+| controller | <code>string</code> | DID of the person/entity controlling this key. |
+| owner | <code>string</code> | DID or URI of owner. DEPRECATED, use  `controller` instead. |
+
+<a name="SerializedLdKey"></a>
+
+## SerializedLdKey : <code>Object</code>
+Serialized LD Key.
+
+**Kind**: global typedef  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| type | <code>Ed25519VerificationKey2018</code> \| <code>RsaVerificationKey2018</code> | The Encryption type. |
+| passphrase | <code>string</code> | The passphrase to generate the pair. |
+
+
+---
+Copyright (c) 2018-2019 Digital Bazaar, Inc. All rights reserved.

--- a/docs/template.hbs
+++ b/docs/template.hbs
@@ -1,0 +1,6 @@
+## Usage
+
+{{>main}}
+
+---
+Copyright (c) 2018-2019 Digital Bazaar, Inc. All rights reserved.

--- a/lib/Ed25519KeyPair.js
+++ b/lib/Ed25519KeyPair.js
@@ -11,10 +11,28 @@ const LDKeyPair = require('./LDKeyPair');
 
 class Ed25519KeyPair extends LDKeyPair {
   /**
-   * @param options {object} See LDKeyPair constructor docstring for full list
-   *
-   * @param [options.publicKeyBase58] {string}
-   * @param [options.privateKeyBase58] {string}
+   * An implementation of
+   * [Ed25519 Signature 2018]{@link https://w3c-dvcg.github.io/lds-ed25519-2018/}
+   * for
+   * [jsonld-signatures.]{@link https://github.com/digitalbazaar/jsonld-signatures}
+   * @example
+   * > const privateKey =
+   *   '3Mmk4UzTRJTEtxaKk61LxtgUxAa2Dg36jF6VogPtRiKvfpsQWKPCLesKSV182RMmvM'
+   *   + 'JKk6QErH3wgdHp8itkSSiF';
+   * > const options = {
+   *   publicKeyBase58: 'GycSSui454dpYRKiFdsQ5uaE8Gy3ac6dSMPcAoQsk8yq',
+   *   privateKeyBase58: privateKey
+   * };
+   * > const EDKey = new Ed25519KeyPair(options);
+   * > EDKey
+   * Ed25519KeyPair { ...
+   * @param {KeyPairOptions} options - Base58 keys plus
+   * other options most follow
+   * [KeyPairOptions]{@link ./index.md#KeyPairOptions}.
+   * @param {string} options.publicKeyBase58 - Base58 encoded Public Key
+   * unencoded is 32-bytes.
+   * @param {string} options.privateKeyBase58 - Base58 Private Key
+   * unencoded is 64-bytes.
    */
   constructor(options = {}) {
     super(options);
@@ -22,21 +40,41 @@ class Ed25519KeyPair extends LDKeyPair {
     this.privateKeyBase58 = options.privateKeyBase58;
     this.publicKeyBase58 = options.publicKeyBase58;
   }
-
+  /**
+   * Returns the Base58 encoded public key.
+   * @implements {LDKeyPair#publicKey}
+   * @readonly
+   *
+   * @returns {string} The Base58 encoded public key.
+   * @see [publicKey]{@link ./LDKeyPair.md#publicKey}
+   */
   get publicKey() {
     return this.publicKeyBase58;
   }
-
+  /**
+   * Returns the Base58 encoded private key.
+   * @implements {LDKeyPair#privateKey}
+   * @readonly
+   *
+   * @returns {string} The Base58 encoded private key.
+   * @see [privateKey]{@link ./LDKeyPair.md#privateKey}
+   */
   get privateKey() {
     return this.privateKeyBase58;
   }
 
   /**
-   * @param [options] {object} See LDKeyPair docstring for full list
-   * @param [options.seed] {(Uint8Array|Buffer)} a 32-byte seed for a
-   *   deterministic key.
+   * Generates a KeyPair with an optional deterministic seed.
+   * @example
+   * > const keyPair = await Ed25519KeyPair.generate();
+   * > keyPair
+   * Ed25519KeyPair { ...
+   * @param {KeyPairOptions} [options={}] - See LDKeyPair
+   * docstring for full list.
+   * @param {Uint8Array|Buffer} [options.seed] -
+   * a 32-byte array seed for a deterministic key.
    *
-   * @returns {Promise<Ed25519KeyPair>}
+   * @returns {Promise<Ed25519KeyPair>} Generates a key pair.
    */
   static async generate(options = {}) {
     if(env.nodejs) {
@@ -68,7 +106,22 @@ class Ed25519KeyPair extends LDKeyPair {
       ...options
     });
   }
-
+  /**
+   * Creates an Ed25519 Key Pair from an existing private key.
+   * @example
+   * > const options = {
+   *   privateKeyBase58: privateKey
+   * };
+   * > const key = await Ed25519KeyPair.from(options);
+   * > key
+   * Ed25519KeyPair { ...
+   * @param {Object} options - Contains a private key.
+   * @param {Object} [options.privateKey] - A private key object.
+   * @param {string} [options.privateKeyBase58] - A Base58
+   * Private key string.
+   *
+   * @returns {Ed25519KeyPair} An Ed25519 Key Pair.
+   */
   static async from(options) {
     const privateKeyBase58 = options.privateKeyBase58 ||
       // legacy privateDidDoc format
@@ -83,28 +136,56 @@ class Ed25519KeyPair extends LDKeyPair {
   }
 
   /**
-   * Returns a signer object for use with jsonld-signatures.
+   * Returns a signer object for use with
+   * [jsonld-signatures]{@link https://github.com/digitalbazaar/jsonld-signatures}.
+   * @example
+   * > const signer = keyPair.signer();
+   * > signer
+   * { sign: [AsyncFunction: sign] }
+   * > signer.sign({data});
    *
-   * @returns {{sign: function}}
+   * @returns {{sign: Function}} A signer for the json-ld block.
    */
   signer() {
     return ed25519SignerFactory(this);
   }
 
   /**
-   * Returns a verifier object for use with jsonld-signatures.
+   * Returns a verifier object for use with
+   * [jsonld-signatures]{@link https://github.com/digitalbazaar/jsonld-signatures}.
+   * @example
+   * > const verifier = keyPair.verifier();
+   * > verifier
+   * { verify: [AsyncFunction: verify] }
+   * > verifier.verify(key);
    *
-   * @returns {{verify: function}}
+   * @returns {{verify: Function}} Used to verify jsonld-signatures.
    */
   verifier() {
     return ed25519VerifierFactory(this);
   }
-
+  /**
+   * Adds a public key base to a public key node.
+   * @example
+   * > keyPair.addEncodedPublicKey({});
+   * { publicKeyBase58: 'GycSSui454dpYRKiFdsQ5uaE8Gy3ac6dSMPcAoQsk8yq' }
+   * @param {Object} publicKeyNode - The public key node in a jsonld-signature.
+   * @param {string} publicKeyNode.publicKeyBase58 - Base58 Public Key for
+   * [jsonld-signatures]{@link https://github.com/digitalbazaar/jsonld-signatures}.
+   *
+   * @returns {{verify: Function}} A PublicKeyNode in a block.
+   */
   addEncodedPublicKey(publicKeyNode) {
     publicKeyNode.publicKeyBase58 = this.publicKeyBase58;
     return publicKeyNode;
   }
 
+  /**
+   * Adds an encrypted private key to the KeyPair.
+   * @param {Object} keyNode - A plain object.
+   *
+   * @return {Object} The keyNode with an encrypted private key attached.
+   */
   async addEncryptedPrivateKey(keyNode) {
     if(this.passphrase !== null) {
       keyNode.privateKeyJwe = await this.encrypt(
@@ -119,10 +200,15 @@ class Ed25519KeyPair extends LDKeyPair {
   }
 
   /**
-   * @param privateKey
-   * @param password
+   * Produces a 32-byte encrypted key.
+   * @example
+   * > const encryptedContent = await edKeyPair
+   *   .encrypt(privateKey, 'Test1244!');
+   * @param {string} privateKey - The base58 private key.
+   * @param {string} password - The password.
    *
-   * @returns {Promise<JWE>}
+   * @returns {Promise<JWE>} Produces JSON Web encrypted content.
+   * @see [JWE]{@link ./index.md#JWE}
    */
   async encrypt(privateKey, password) {
     const keySize = 32;
@@ -160,6 +246,14 @@ class Ed25519KeyPair extends LDKeyPair {
     return jwe;
   }
 
+  /**
+   * Decrypts jwe content to a privateKey.
+   * @param {JWE} jwe - Encrypted content from a block.
+   * @param {string} password - Password for the key used to sign the content.
+   *
+   * @returns {Object} A Base58 private key.
+   * @see [JWE]{@link ./index.md#JWE}
+   */
   async decrypt(jwe, password) {
     // FIXME: check header, implement according to JWE standard
     const keySize = 32;
@@ -183,12 +277,14 @@ class Ed25519KeyPair extends LDKeyPair {
   }
 
   /**
-   * Generates and returns a Multiformat encoded ed25519 public key fingerprint
-   * (for use with cryptonyms, for example).
-   *
+   * Generates and returns a multiformats encoded
+   * ed25519 public key fingerprint (for use with cryptonyms, for example).
+   * @example
+   * > edKeyPair.fingerprint();
+   * z6dfdsfdsfds3432423
    * @see https://github.com/multiformats/multicodec
    *
-   * @returns {string}
+   * @returns {string} A verifiable cryptographic signature.
    */
   fingerprint() {
     const buffer = new forge.util.createBuffer();
@@ -203,19 +299,23 @@ class Ed25519KeyPair extends LDKeyPair {
     buffer.putBytes(forge.util.hexToBytes('ed01'));
     buffer.putBytes(pubkeyBytes.toString('binary'));
 
-    // prefix with `z` to indicate multibase base58btc encoding
+    // prefix with `z` to indicate multi-base base58btc encoding
     return `z${base58.encode(buffer)}`;
   }
 
   /**
-   * Tests whether the fingerprint was generated from a given key pair.
+   * Tests whether the fingerprint was
+   * generated from a given key pair.
+   * @example
+   * > edKeyPair.verifyFingerprint('z2S2Q6MkaFJewa');
+   * {valid: true};
+   * @param {string} fingerprint - A Base58 public key.
    *
-   * @param fingerprint {string}
-   *
-   * @returns {boolean}
+   * @returns {Object} An object indicating valid is true or false.
    */
   verifyFingerprint(fingerprint) {
-    // fingerprint should have `z` prefix indicating that it's multibase encoded
+    // fingerprint should have `z` prefix indicating
+    // that it's multi-base encoded
     if(!(typeof fingerprint === 'string' && fingerprint[0] === 'z')) {
       return {
         error: new Error('`fingerprint` must be a multibase encoded string.'),
@@ -257,9 +357,17 @@ class Ed25519KeyPair extends LDKeyPair {
 }
 
 /**
- * Returns a signer object for use with jsonld-signatures.
+ * @ignore
+ * Returns an object with an async sign function.
+ * The sign function is bound to the KeyPair
+ * and then returned by the KeyPair's signer method.
+ * @param {Ed25519KeyPair} key - An ED25519KeyPair.
+ * @example
+ * > const mySigner = ed25519SignerFactory(edKeyPair);
+ * > await mySigner.sign({data})
  *
- * @returns {{sign: function}}
+ * @returns {{sign: Function}} An object with an async function sign
+ * using the private key passed in.
  */
 function ed25519SignerFactory(key) {
   if(!key.privateKeyBase58) {
@@ -304,9 +412,17 @@ function ed25519SignerFactory(key) {
 }
 
 /**
- * Returns a verifier object for use with jsonld-signatures.
+ * @ignore
+ * Returns an object with an async verify function.
+ * The verify function is bound to the KeyPair
+ * and then returned by the KeyPair's verifier method.
+ * @param {Ed25519KeyPair} key - An Ed25519KeyPair.
+ * @example
+ * > const myVerifier = ed25519Verifier(edKeyPair);
+ * > await myVerifier.verify({data, signature});
  *
- * @returns {{verify: function}}
+ * @returns {{verify: Function}} An async verifier specific
+ * to the key passed in.
  */
 function ed25519VerifierFactory(key) {
   if(env.nodejs) {
@@ -341,15 +457,24 @@ function ed25519VerifierFactory(key) {
 }
 
 /**
- * Wrap Base58 decoding operations in order to provide consistent error
- * messages.
+ * Wraps Base58 decoding operations in
+ * order to provide consistent error messages.
+ * @ignore
+ * @example
+ * > const pubkeyBytes = _base58Decode({
+ *    decode: base58.decode,
+ *    keyMaterial: this.publicKeyBase58,
+ *    type: 'public'
+ *   });
+ * @param {Object} options - The decoder options.
+ * @param {Function} options.decode - The decode function to use.
+ * @param {string} options.keyMaterial - The Base58 encoded
+ * key material to decode.
+ * @param {string} options.type - A description of the
+ * key material that will be included
+ * in an error message (e.g. 'public', 'private').
  *
- * @param {function} decode - the decode function to use.
- * @param {string} keyMaterial - the Base58 encoded key material to decode.
- * @param {string} type - a description of the keyMaterial that will be included
- *   in an error message (e.g. 'public', 'private').
- *
- * @returns {bytes} - the decoded bytes. The data structure for the bytes is
+ * @returns {Object} - The decoded bytes. The data structure for the bytes is
  *   determined by the provided decode function.
  */
 function _base58Decode({decode, keyMaterial, type}) {

--- a/lib/LDKeyPair.js
+++ b/lib/LDKeyPair.js
@@ -7,17 +7,21 @@ const forge = require('node-forge');
 
 class LDKeyPair {
   /**
-   * Note: Actual key material (like `publicKeyBase58` for Ed25519 or
+   *  Note: Actual key material
+   * (like `publicKeyBase58` for Ed25519 or
    * `publicKeyPem` for RSA) is handled in the subclass.
-   *
-   * @param [options={}] {object}
-   * @param [options.passphrase=null] {string} For encrypting the private key
-   *
-   * @param [options.id] {string} Key id
-   *
-   * @param [options.controller] {string} DID of the person/entity controlling
-   *   this key
-   * @param [options.owner] {string} DID or URI of owner. DEPRECATED, use
+   * An LDKeyPair can encrypt private key material.
+   * @classdesc The Abstract Base Class on which KeyPairs are based.
+   * @example
+   * // LDKeyPair is an Abstract Class and should only
+   * // be used as a base class for other KeyPairs.
+   * @param {KeyPairOptions} [options={}] -
+   * See [KeyPairOptions]{@link ./index.md#KeyPairOptions}.
+   * @param {string} [options.passphrase=null] - For encrypting the private key.
+   * @param {string} options.id - The Key id.
+   * @param {string} options.controller - DID of the person/entity controlling
+   *   this key.
+   * @param {string} [options.owner]  - DID or URI of owner. DEPRECATED, use
    *  `controller` instead.
    */
   constructor(options = {}) {
@@ -26,29 +30,45 @@ class LDKeyPair {
     this.controller = options.controller;
     this.owner = options.owner;
     // this.type is set in subclass constructor
-    // this.publicKey* and this.privateKey* is handled in subclasses
+    // this.publicKey* and this.privateKey* is handled in sub-classes
   }
-
   /**
-   * Returns subclass-appropriate public key material.
+   * @abstract
+   * @interface
+   * @readonly
+   *  Returns the public key.
+   * @throws  If not implemented by the subclass.
+   *
+   * @returns {string} A public key.
    */
   get publicKey() {
     throw new Error('Abstract method, must be implemented in subclass.');
   }
-
   /**
-   * Returns subclass-appropriate private key material.
+   * @abstract
+   * @interface
+   * @readonly
+   *  Returns the private key.
+   * @throws If not implemented by the subclass.
+   *
+   * @returns {string} A private key.
    */
   get privateKey() {
     throw new Error('Abstract method, must be implemented in subclass.');
   }
-
   /**
-   * @param [options]
-   * @param [options.type] {string} Key type
-   * @param [options.passphrase]
+   * Generates an LdKeyPair using SerializedLdKey options.
+   * @param {SerializedLdKey} options - Options for generating the KeyPair.
+   * @example
+   * > const options = {
+   *    type: 'RsaVerificationKey2018',
+   *    passphrase: 'Test1234'
+   *  };
+   * > const keyPair = await LDKeyPair.generate(options);
    *
-   * @returns {Promise<LDKeyPair>}
+   * @returns {Promise<LDKeyPair>} An LDKeyPair.
+   * @throws Unsupported Key Type.
+   * @see [SerializedLdKey]{@link ./index.md#SerializedLdKey}
    */
   static async generate(options) {
     switch(options.type) {
@@ -66,14 +86,19 @@ class LDKeyPair {
   }
 
   /**
-   * @param options {object} Serialized LD key object
+   * Generates a KeyPair from some options.
+   * @param {SerializedLdKey} options  - Will generate a key pair
+   * in multiple different formats.
+   * @see [SerializedLdKey]{@link ./index.md#SerializedLdKey}
+   * @example
+   * > const options = {
+   *    type: 'Ed25519VerificationKey2018',
+   *    passphrase: 'Test1234'
+   *   };
+   * > const edKeyPair = await LDKeyPair.from(options);
    *
-   * @param [options.type] {string} Key type
-   *
-   * @param [options]
-   * @param [options.passphrase]
-   *
-   * @returns {Promise<LDKeyPair>}
+   * @returns {Promise<LDKeyPair>} A LDKeyPair.
+   * @throws Unsupported Key Type.
    */
   static async from(options) {
     switch(options.type) {
@@ -89,7 +114,19 @@ class LDKeyPair {
         throw new Error(`Unsupported Key Type: ${options.type}`);
     }
   }
-
+  /**
+   * Generates a
+   * [pdkdf2]{@link https://en.wikipedia.org/wiki/PBKDF2} key.
+   * @param {string} password - The password for the key.
+   * @param {string} salt - Noise used to randomize the key.
+   * @param {number} iterations - The number of times to run the algorithm.
+   * @param {number} keySize - The byte length of the key.
+   * @example
+   * > const key = await LdKeyPair.pbkdf2('Test1234', salt, 10, 32);
+   *
+   * @returns {Promise<Object>} A promise that resolves to a pdkdf2 key.
+   * @see https://github.com/digitalbazaar/forge#pkcs5
+   */
   static async pbkdf2(password, salt, iterations, keySize) {
     return new Promise((resolve, reject) => {
       forge.pkcs5.pbkdf2(password, salt, iterations, keySize, (err, key) =>
@@ -98,9 +135,19 @@ class LDKeyPair {
   }
 
   /**
-   * @param [controller] {string} DID of the person/entity controlling this key
+   * Contains the encryption type & public key for the KeyPair
+   * and other information that json-ld Signatures can use to form a proof.
+   * @param {Object} [options={}] - Needs either a controller or owner.
+   * @param {string} [options.controller=this.controller]  - DID of the
+   * person/entity controlling this key pair.
+   * @param {string} [options.owner=this.owner] - DID of key owner.
+   * Deprecated term, use `controller`.
+   * @example
+   * > ldKeyPair.publicNode();
+   * {id: 'test-keypair-id', owner: 'did:uuid:example'}
    *
-   * @param [owner] {string} DID of key owner. Deprecated term, use `controller`
+   * @returns {Object} A public node with
+   * information used in verification methods by signatures.
    */
   publicNode({controller = this.controller, owner = this.owner} = {}) {
     const publicNode = {
@@ -118,6 +165,14 @@ class LDKeyPair {
   }
 
   // publicKeyPem, publicKeyJwk, publicKeyHex, publicKeyBase64, publicKeyBase58
+  /**
+   * Exports the publicNode with an encrypted private key attached.
+   * @example
+   * > const withPrivateKey = await edKeyPair.export();
+   *
+   * @returns {KeyPairOptions} A public node with encrypted private key.
+   * @see [KeyPairOptions]{@link ./index.md#KeyPairOptions}
+   */
   async export() {
     const keyNode = this.publicNode();
     return this.addEncryptedPrivateKey(keyNode); // Subclass-specific

--- a/lib/RSAKeyPair.js
+++ b/lib/RSAKeyPair.js
@@ -12,10 +12,37 @@ const {
 } = forge;
 const LDKeyPair = require('./LDKeyPair');
 
+/**
+ * @constant
+ * @type {number}
+ * @default
+ */
 const DEFAULT_RSA_KEY_BITS = 2048;
+
+/**
+ * @constant
+ * @type {number}
+ * @default
+ */
 const DEFAULT_RSA_EXPONENT = 0x10001;
 
 class RSAKeyPair extends LDKeyPair {
+  /**
+   * An implementation of
+   * [RSA encryption]{@link https://simple.wikipedia.org/wiki/RSA_algorithm}
+   * for
+   * [jsonld-signatures]{@link https://github.com/digitalbazaar/jsonld-signatures}.
+   * @example
+   * > const options = {
+   *    privateKeyPem: 'testPrivateKey',
+   *    publicKeyPem: 'testPublicKey'
+   *  };
+   * > const RSAKey = new RSAKeyPair(options);
+   * @param {KeyPairOptions} options - Keys must be in RSA format other
+   * options must follow [KeyPairOptions]{@link ./index.md#KeyPairOptions}.
+   * @param {string} options.publicKeyPem - Public Key for Signatures.
+   * @param {string} options.privateKeyPem - Your Confidential key for signing.
+   */
   constructor(options = {}) {
     super(options);
     this.type = 'RsaVerificationKey2018';
@@ -24,18 +51,40 @@ class RSAKeyPair extends LDKeyPair {
 
     this.validateKeyParams(); // validate keyBits and exponent
   }
-
+  /**
+   * Returns the public key.
+   * @implements {LDKeyPair#publicKey}
+   * @readonly
+   *
+   * @returns {string} The public key.
+   * @see [publicKey]{@link ./LDKeyPair.md#publicKey}
+   */
   get publicKey() {
     return this.publicKeyPem;
   }
-
+  /**
+   * Returns the private key.
+   * @implements {LDKeyPair#privateKey}
+   * @readonly
+   *
+   * @returns {string} The private key.
+   * @see [privateKey]{@link ./LDKeyPair.md#privateKey}
+   */
   get privateKey() {
     return this.privateKeyPem;
   }
 
   /**
-   * @param options
-   * @returns {Promise<RSAKeyPair>}
+   * Generates an RSA KeyPair using the RSA Defaults.
+   * @example
+   * > const keyPair = await RSAKeyPair.generate();
+   * > keyPair
+   * RSAKeyPair { ...
+   * @param {KeyPairOptions} [options={}] - See LDKeyPair
+   * docstring for full list.
+   *
+   * @returns {Promise<RSAKeyPair>} A Default encrypted RSA KeyPair.
+   * @see [KeyPairOptions]{@link ./index.md#KeyPairOptions}
    */
   static async generate(options = {}) {
     // forge will use a native implementation in nodejs >= 10.12.0
@@ -57,7 +106,19 @@ class RSAKeyPair extends LDKeyPair {
       });
     });
   }
-
+  /**
+   * Creates a RSA Key Pair from an existing private key.
+   * @example
+   * > const options = {
+   *    privateKeyPem: 'testkeypem'
+   *  };
+   * > const key = await RSAKeyPair.from(options);
+   * @param {Object} options - Contains a private key.
+   * @param {Object} [options.privateKey] - A private key.
+   * @param {string} [options.privateKeyPem] - An RSA Private key.
+   *
+   * @returns {RSAKeyPair} An RSA Key Pair.
+   */
   static async from(options) {
     const privateKeyPem = options.privateKeyPem ||
       // legacy privateDidDoc format
@@ -72,7 +133,16 @@ class RSAKeyPair extends LDKeyPair {
 
     return keys;
   }
-
+  /**
+   * Validates this key.
+   * @example
+   * > rsaKeyPair.validateKeyParams();
+   * undefined
+   *
+   * @returns {undefined} If it does not throw then the key is valid.
+   * @throws Invalid RSA keyBit length
+   * @throws Invalid RSA exponent
+   */
   validateKeyParams() {
     if(this.publicKeyPem) {
       const publicKey = forge.pki.publicKeyFromPem(this.publicKeyPem);
@@ -103,11 +173,30 @@ class RSAKeyPair extends LDKeyPair {
     }
   }
 
+  /**
+   * Adds this KeyPair's publicKeyPem to a public node.
+   * @example
+   * > rsaKeyPair.addEncodedPublicKey({id: 'testnode'});
+   * { publicKeyPem: 'testPublicKey' }
+   * @param {KeyPairOptions} publicKeyNode - A Node with out a publicKeyPem set.
+   *
+   * @returns {KeyPairOptions} A public node with a publicKeyPem set.
+   * @see [KeyPairOptions]{@link ./index.md#KeyPairOptions}
+   */
   addEncodedPublicKey(publicKeyNode) {
     publicKeyNode.publicKeyPem = this.publicKeyPem;
     return publicKeyNode;
   }
-
+  /**
+   * Adds this KeyPair's privateKeyPem to a public node.
+   * @example
+   * > rsaKeyPair.addEncryptedPrivateKey({id: 'testnode'});
+   * { privateKeyPem: 'testPrivateKey' }
+   * @param {KeyPairOptions} keyNode - A Node with out a publicKeyPem set.
+   *
+   * @returns {KeyPairOptions} A public node with a privateKeyPem set.
+   * @see [KeyPairOptions]{@link ./index.md#KeyPairOptions}
+   */
   async addEncryptedPrivateKey(keyNode) {
     if(this.passphrase !== null) {
       keyNode.privateKeyPem = forge.pki.encryptRsaPrivateKey(
@@ -123,10 +212,13 @@ class RSAKeyPair extends LDKeyPair {
   }
 
   /**
-   * Generates and returns a Multiformat encoded RSA public key fingerprint
-   * (for use with cryptonyms, for example).
+   * Generates and returns a multiformats
+   * encoded RSA public key fingerprint (for use with cryptonyms, for example).
+   * @example
+   * > rsaKeyPair.fingerprint();
+   * 3423dfdsf3432sdfdsds
    *
-   * @returns {string}
+   * @returns {string} An RSA fingerprint.
    */
   fingerprint() {
     const buffer = forge.util.createBuffer();
@@ -135,25 +227,29 @@ class RSAKeyPair extends LDKeyPair {
     const fingerprintBuffer = forge.pki.getPublicKeyFingerprint(
       forge.pki.publicKeyFromPem(this.publicKeyPem),
       {md: sha256.create()});
-    // RSA cryptonyms are multiformat encoded values, specifically they are:
+    // RSA cryptonyms are multiformats encoded values, specifically they are:
     // (multicodec RSA SPKI-based public key 0x5d + sha2-256 0x12 +
     // 32 byte value 0x20)
     buffer.putBytes(forge.util.hexToBytes('5d1220'));
     buffer.putBytes(fingerprintBuffer.bytes());
 
-    // prefix with `z` to indicate multibase base58btc encoding
+    // prefix with `z` to indicate multi-base base58btc encoding
     return `z${base58.encode(buffer)}`;
   }
 
   /*
-   * Tests whether the fingerprint was generated from a given key pair.
+   * Tests whether the fingerprint
+   * was generated from a given key pair.
+   * @example
+   * > rsaKeyPair.verifyFingerprint('zdsfdsfsdfdsfsd34234');
+   * {valid: true}
+   * @param {string} fingerprint - An RSA fingerprint for a key.
    *
-   * @param fingerprint {string}
-   *
-   * @returns {boolean}
+   * @returns {boolean} True if the fingerprint is verified.
    */
   verifyFingerprint(fingerprint) {
-    // fingerprint should have `z` prefix indicating that it's multibase encoded
+    // fingerprint should have `z` prefix indicating
+    // that it's multi-base encoded
     if(!(typeof fingerprint === 'string' && fingerprint[0] === 'z')) {
       return {
         error: new Error('`fingerprint` must be a multibase encoded string.'),
@@ -181,18 +277,29 @@ class RSAKeyPair extends LDKeyPair {
   }
 
   /**
-   * Returns a signer object for use with jsonld-signatures.
+   * Returns a signer object with an async sign function for use by
+   * [jsonld-signatures]{@link https://github.com/digitalbazaar/jsonld-signatures}
+   * to sign content in a signature.
+   * @example
+   * > const signer = rsaKeyPair.signer();
+   * > signer.sign({data});
    *
-   * @returns {{sign: function}}
+   * @returns {{sign: Function}} An RSA Signer Function for a single key.
+   * for a single Private Key.
    */
   signer() {
     return rsaSignerFactory(this);
   }
 
   /**
-   * Returns a verifier object for use with jsonld-signatures.
+   * Returns a verifier object with an async
+   * function verify for use with
+   * [jsonld-signatures]{@link https://github.com/digitalbazaar/jsonld-signatures}.
+   * @example
+   * > const verifier = rsaKeyPair.verifier();
+   * > const valid = await verifier.verify({data, signature});
    *
-   * @returns {{verify: function}}
+   * @returns {{verify: Function}} An RSA Verifier Function for a single key.
    */
   verifier() {
     return rsaVerifierFactory(this);
@@ -200,9 +307,16 @@ class RSAKeyPair extends LDKeyPair {
 }
 
 /**
- * Returns a signer object for use with jsonld-signatures.
+ * @ignore
+ * Returns an object with an async sign function.
+ * The sign function is bound to the KeyPair
+ * and then returned by the KeyPair's signer method.
+ * @example
+ * > const factory = rsaSignerFactory(rsaKeyPair);
+ * > const bytes = await factory.sign({data});
+ * @param {RSAKeyPair} key - They key this factory will verify for.
  *
- * @returns {{sign: function}}
+ * @returns {{sign: Function}} An RSA Verifier Function for a single key.
  */
 function rsaSignerFactory(key) {
   if(!key.privateKeyPem) {
@@ -252,6 +366,19 @@ function rsaSignerFactory(key) {
   };
 }
 
+/**
+ * @ignore
+ * Returns an object with an async verify function.
+ * The verify function is bound to the KeyPair
+ * and then returned by the KeyPair's verifier method.
+ * @example
+ * > const verifier = rsaVerifierFactory(rsaKeyPair);
+ * > verifier.verify({data, signature});
+ * false
+ * @param {RSAKeyPair} key - An RSAKeyPair.
+ *
+ * @returns {Function} An RSA Verifier for the key pair passed in.
+ */
 function rsaVerifierFactory(key) {
   if(env.nodejs) {
     // node.js 8+
@@ -293,6 +420,15 @@ function rsaVerifierFactory(key) {
   };
 }
 
+/**
+ * @ignore
+ * creates an RSA PSS used in signatures.
+ * @example
+ * > const pss = createPss();
+ *
+ * @returns {PSS} A PSS object.
+ * @see [PSS]{@link ./index.md#PSS}
+ */
 function createPss() {
   const md = sha256.create();
   return forge.pss.create({

--- a/lib/env.js
+++ b/lib/env.js
@@ -3,7 +3,6 @@
  */
 'use strict';
 
-// determine if using node.js or browser
 const nodejs = (
   typeof process !== 'undefined' && process.versions && process.versions.node);
 const browser = !nodejs &&

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,3 +8,39 @@ module.exports = {
   LDKeyPair: require('./LDKeyPair'),
   RSAKeyPair: require('./RSAKeyPair'),
 };
+
+/**
+ * [JSON Web encryption]{@link https://tools.ietf.org/html/rfc7516}
+ * @typedef {Object} JWE
+ * @property {string} unprotected - A header for the jwe.
+ * @property {string} iv - A base64 url.
+ * @property {string} ciphertext - A base64 url.
+ * @property {string} tag - A base64 url.
+ */
+
+/**
+ * PSS Object
+ * @typedef {Object} PSS
+ * @property encode {Function}
+ * @property verify {Function}
+ */
+
+/**
+ * KeyPair Options.
+ * @typedef {Object} KeyPairOptions
+ * @property {string} passphrase - For encrypting the private key.
+ * @property {string} id - Key Id.
+ * @property {string} controller -
+ * DID of the person/entity controlling this key.
+ * @property {string} owner - DID or URI of owner. DEPRECATED, use
+ *  `controller` instead.
+ */
+
+/**
+ * Serialized LD Key.
+ * @typedef {Object} SerializedLdKey
+ * @property {Ed25519VerificationKey2018|RsaVerificationKey2018}
+ * type - The Encryption type.
+ * @property {string} passphrase - The passphrase to generate the pair.
+ */
+

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "cross-env": "^5.1.3",
     "eslint": "^5.14.1",
     "eslint-config-digitalbazaar": "^1.5.0",
+    "jsdoc-to-markdown": "^4.0.1",
     "karma": "^3.1.1",
     "karma-babel-preprocessor": "^8.0.0",
     "karma-chrome-launcher": "^2.2.0",
@@ -93,6 +94,7 @@
     "benchmark": "node benchmark/benchmark.js",
     "coverage": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text-summary npm run test-node",
     "coverage-report": "nyc report",
-    "lint": "eslint lib tests"
+    "lint": "eslint lib tests",
+    "generate-docs": "node docs/generate.js"
   }
 }


### PR DESCRIPTION
There might still be typos in this file (especially in RSAKeyPair), but have gone over this a lot.
Major things needed in this PR is corrections on the docs or ways to clarify the relationship between this project and jsonld-signatures.

Just figured getting the actual PR in means you guys can look at it which is probably faster. Than me reading more of the related project's code.

check the README in the this branch to see the product of the work.
Really need a better handle on handlebar templates are being used by jsdoc-to-markdown.

Also of note:
please note abstract methods do not lint well i.e. the linter for check return fails on them.