### PR TITLE
Export base58PublicKeyFingerprint helper.

### DIFF
--- a/lib/Ed25519KeyPair.js
+++ b/lib/Ed25519KeyPair.js
@@ -7,6 +7,7 @@ const env = require('./env');
 const forge = require('node-forge');
 const base64url = require('base64url-universal');
 const {pki: {ed25519}, util: {binary: {base58}}} = forge;
+const util = require('./util');
 const LDKeyPair = require('./LDKeyPair');
 
 class Ed25519KeyPair extends LDKeyPair {
@@ -280,27 +281,12 @@ class Ed25519KeyPair extends LDKeyPair {
   /**
    * Generates and returns a multiformats encoded
    * ed25519 public key fingerprint (for use with cryptonyms, for example).
-   * @example
-   * > edKeyPair.fingerprint();
-   * z6dfdsfdsfds3432423
    * @see https://github.com/multiformats/multicodec
    *
-   * @returns {string} A verifiable cryptographic signature.
+   * @returns {string} The fingerprint.
    */
   fingerprint() {
-    // ed25519 cryptonyms are multicodec encoded values, specifically:
-    // (multicodec ed25519-pub 0xed01 + key bytes)
-    const pubkeyBytes = _base58Decode({
-      decode: base58.decode,
-      keyMaterial: this.publicKeyBase58,
-      type: 'public'
-    });
-    const buffer = new Uint8Array(2 + pubkeyBytes.length);
-    buffer[0] = 0xed;
-    buffer[1] = 0x01;
-    buffer.set(pubkeyBytes, 2);
-    // prefix with `z` to indicate multi-base base58btc encoding
-    return `z${base58.encode(buffer)}`;
+    return util.base58PublicKeyFingerprint({keyMaterial: this.publicKeyBase58});
   }
 
   /**
@@ -324,7 +310,7 @@ class Ed25519KeyPair extends LDKeyPair {
     }
     let fingerprintBuffer;
     try {
-      fingerprintBuffer = _base58Decode({
+      fingerprintBuffer = util.base58Decode({
         decode: base58.decode,
         keyMaterial: fingerprint.slice(1),
         type: `fingerprint's`
@@ -334,7 +320,7 @@ class Ed25519KeyPair extends LDKeyPair {
     }
     let publicKeyBuffer;
     try {
-      publicKeyBuffer = _base58Decode({
+      publicKeyBuffer = util.base58Decode({
         decode: base58.decode,
         keyMaterial: this.publicKeyBase58,
         type: 'public'
@@ -381,7 +367,7 @@ function ed25519SignerFactory(key) {
   if(env.nodejs) {
     const sodium = require('sodium-native');
     const bs58 = require('bs58');
-    const privateKey = _base58Decode({
+    const privateKey = util.base58Decode({
       decode: bs58.decode,
       keyMaterial: key.privateKeyBase58,
       type: 'private'
@@ -399,7 +385,7 @@ function ed25519SignerFactory(key) {
   }
 
   // browser implementation
-  const privateKey = _base58Decode({
+  const privateKey = util.base58Decode({
     decode: base58.decode,
     keyMaterial: key.privateKeyBase58,
     type: 'private'
@@ -428,7 +414,7 @@ function ed25519VerifierFactory(key) {
   if(env.nodejs) {
     const sodium = require('sodium-native');
     const bs58 = require('bs58');
-    const publicKey = _base58Decode({
+    const publicKey = util.base58Decode({
       decode: bs58.decode,
       keyMaterial: key.publicKeyBase58,
       type: 'public'
@@ -444,7 +430,7 @@ function ed25519VerifierFactory(key) {
   }
 
   // browser implementation
-  const publicKey = _base58Decode({
+  const publicKey = util.base58Decode({
     decode: base58.decode,
     keyMaterial: key.publicKeyBase58,
     type: 'public'
@@ -454,42 +440,6 @@ function ed25519VerifierFactory(key) {
       return ed25519.verify({message: data, signature, publicKey});
     }
   };
-}
-
-/**
- * Wraps Base58 decoding operations in
- * order to provide consistent error messages.
- * @ignore
- * @example
- * > const pubkeyBytes = _base58Decode({
- *    decode: base58.decode,
- *    keyMaterial: this.publicKeyBase58,
- *    type: 'public'
- *   });
- * @param {Object} options - The decoder options.
- * @param {Function} options.decode - The decode function to use.
- * @param {string} options.keyMaterial - The Base58 encoded
- * key material to decode.
- * @param {string} options.type - A description of the
- * key material that will be included
- * in an error message (e.g. 'public', 'private').
- *
- * @returns {Object} - The decoded bytes. The data structure for the bytes is
- *   determined by the provided decode function.
- */
-function _base58Decode({decode, keyMaterial, type}) {
-  let bytes;
-  try {
-    bytes = decode(keyMaterial);
-  } catch(e) {
-    // do nothing
-    // the bs58 implementation throws, forge returns undefined
-    // this helper throws when no result is produced
-  }
-  if(bytes === undefined) {
-    throw new TypeError(`The ${type} key material must be Base58 encoded.`);
-  }
-  return bytes;
 }
 
 module.exports = Ed25519KeyPair;

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@ module.exports = {
   Ed25519KeyPair: require('./Ed25519KeyPair'),
   LDKeyPair: require('./LDKeyPair'),
   RSAKeyPair: require('./RSAKeyPair'),
+  util: require('./util'),
 };
 
 /**
@@ -43,4 +44,3 @@ module.exports = {
  * type - The Encryption type.
  * @property {string} passphrase - The passphrase to generate the pair.
  */
-

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2018-2019 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const {util: {binary: {base58}}} = require('node-forge');
+
+/**
+ * Wraps Base58 decoding operations in
+ * order to provide consistent error messages.
+ * @ignore
+ * @example
+ * > const pubkeyBytes = _base58Decode({
+ *    decode: base58.decode,
+ *    keyMaterial: this.publicKeyBase58,
+ *    type: 'public'
+ *   });
+ * @param {Object} options - The decoder options.
+ * @param {Function} options.decode - The decode function to use.
+ * @param {string} options.keyMaterial - The Base58 encoded
+ * key material to decode.
+ * @param {string} options.type - A description of the
+ * key material that will be included
+ * in an error message (e.g. 'public', 'private').
+ *
+ * @returns {Object} - The decoded bytes. The data structure for the bytes is
+ *   determined by the provided decode function.
+ */
+exports.base58Decode = ({decode, keyMaterial, type}) => {
+  let bytes;
+  try {
+    bytes = decode(keyMaterial);
+  } catch(e) {
+    // do nothing
+    // the bs58 implementation throws, forge returns undefined
+    // this helper throws when no result is produced
+  }
+  if(bytes === undefined) {
+    throw new TypeError(`The ${type} key material must be Base58 encoded.`);
+  }
+  return bytes;
+};
+
+/**
+ * Generates and returns a multiformats encoded
+ * ed25519 public key fingerprint (for use with cryptonyms, for example).
+ * @see https://github.com/multiformats/multicodec
+ *
+ * @param {string} keyMaterial - The base58 encoded public key material.
+ *
+ * @returns {string} The fingerprint.
+ */
+exports.base58PublicKeyFingerprint = ({keyMaterial}) => {
+  // ed25519 cryptonyms are multicodec encoded values, specifically:
+  // (multicodec ed25519-pub 0xed01 + key bytes)
+  const pubkeyBytes = exports.base58Decode({
+    decode: base58.decode,
+    keyMaterial,
+    type: 'public'
+  });
+  const buffer = new Uint8Array(2 + pubkeyBytes.length);
+  buffer[0] = 0xed;
+  buffer[1] = 0x01;
+  buffer.set(pubkeyBytes, 2);
+  // prefix with `z` to indicate multi-base base58btc encoding
+  return `z${base58.encode(buffer)}`;
+};


### PR DESCRIPTION
The purpose of this is to export a `util.base58PublicKeyFingerprint` helper for use in other modules.  We don't want to duplicate this code elsewhere.