### PR TITLE
Implement static fingerprintFromPublicKey API.

### DIFF
--- a/lib/Ed25519KeyPair.js
+++ b/lib/Ed25519KeyPair.js
@@ -283,10 +283,36 @@ class Ed25519KeyPair extends LDKeyPair {
    * ed25519 public key fingerprint (for use with cryptonyms, for example).
    * @see https://github.com/multiformats/multicodec
    *
+   * @param {string} publicKeyBase58 - The base58 encoded public key material.
+   *
+   * @returns {string} The fingerprint.
+   */
+  static fingerprintFromPublicKey({publicKeyBase58}) {
+    // ed25519 cryptonyms are multicodec encoded values, specifically:
+    // (multicodec ed25519-pub 0xed01 + key bytes)
+    const pubkeyBytes = util.base58Decode({
+      decode: base58.decode,
+      keyMaterial: publicKeyBase58,
+      type: 'public'
+    });
+    const buffer = new Uint8Array(2 + pubkeyBytes.length);
+    buffer[0] = 0xed;
+    buffer[1] = 0x01;
+    buffer.set(pubkeyBytes, 2);
+    // prefix with `z` to indicate multi-base base58btc encoding
+    return `z${base58.encode(buffer)}`;
+  }
+
+  /**
+   * Generates and returns a multiformats encoded
+   * ed25519 public key fingerprint (for use with cryptonyms, for example).
+   * @see https://github.com/multiformats/multicodec
+   *
    * @returns {string} The fingerprint.
    */
   fingerprint() {
-    return util.base58PublicKeyFingerprint({keyMaterial: this.publicKeyBase58});
+    const {publicKeyBase58} = this;
+    return Ed25519KeyPair.fingerprintFromPublicKey({publicKeyBase58});
   }
 
   /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,6 @@ module.exports = {
   Ed25519KeyPair: require('./Ed25519KeyPair'),
   LDKeyPair: require('./LDKeyPair'),
   RSAKeyPair: require('./RSAKeyPair'),
-  util: require('./util'),
 };
 
 /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -3,8 +3,6 @@
  */
 'use strict';
 
-const {util: {binary: {base58}}} = require('node-forge');
-
 /**
  * Wraps Base58 decoding operations in
  * order to provide consistent error messages.
@@ -39,29 +37,4 @@ exports.base58Decode = ({decode, keyMaterial, type}) => {
     throw new TypeError(`The ${type} key material must be Base58 encoded.`);
   }
   return bytes;
-};
-
-/**
- * Generates and returns a multiformats encoded
- * ed25519 public key fingerprint (for use with cryptonyms, for example).
- * @see https://github.com/multiformats/multicodec
- *
- * @param {string} keyMaterial - The base58 encoded public key material.
- *
- * @returns {string} The fingerprint.
- */
-exports.base58PublicKeyFingerprint = ({keyMaterial}) => {
-  // ed25519 cryptonyms are multicodec encoded values, specifically:
-  // (multicodec ed25519-pub 0xed01 + key bytes)
-  const pubkeyBytes = exports.base58Decode({
-    decode: base58.decode,
-    keyMaterial,
-    type: 'public'
-  });
-  const buffer = new Uint8Array(2 + pubkeyBytes.length);
-  buffer[0] = 0xed;
-  buffer[1] = 0x01;
-  buffer.set(pubkeyBytes, 2);
-  // prefix with `z` to indicate multi-base base58btc encoding
-  return `z${base58.encode(buffer)}`;
 };


### PR DESCRIPTION
Moves the public key fingerprint API into the Ed25519KeyPair class.

I propose this is released as a patch to v3.5.