### PR TITLE
Upgrade crypto-ld to version v1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lib/*.js"
   ],
   "dependencies": {
-    "base64url-universal": "^1.0.0",
+    "base64url-universal": "^1.0.1",
     "bs58": "^4.0.1",
     "node-forge": "^0.8.0",
     "sodium-native": "^2.3.0"


### PR DESCRIPTION
The cypto-ld v1.0.0 engine capability is incorrect, so upgrade the
crypto-ld to version v1.0.1.

See also: https://github.com/digitalbazaar/base64url-universal/pull/6