### PR TITLE
 Implement node v12 generate, sign and verify.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - "8"
   - "10"
+  - "12"
 sudo: false
 script:
   - if [ "x$BUNDLER" = "x" ]; then npm run test; fi

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -49,7 +49,7 @@ module.exports = function(config) {
     },
 
     webpack: {
-      mode: 'production',
+      mode: 'development',
       devtool: 'inline-source-map',
       module: {
         rules: [

--- a/lib/Ed25519KeyPair.js
+++ b/lib/Ed25519KeyPair.js
@@ -81,7 +81,10 @@ class Ed25519KeyPair extends LDKeyPair {
     // FIXME: determine exact release that included ed25519 key generation
     if(env.nodejs && require('semver').gte(process.version, '12.0.0')) {
       const bs58 = require('bs58');
-      const {ed25519: {privateKeyFromDer, publicKeyFromDer}} = forge;
+      const {
+        asn1, ed25519: {privateKeyFromAsn1, publicKeyFromAsn1},
+        util: {ByteBuffer}
+      } = forge;
       const {promisify} = require('util');
       const {createPublicKey, generateKeyPair} = require('crypto');
       const publicKeyEncoding = {format: 'der', type: 'spki'};
@@ -92,14 +95,16 @@ class Ed25519KeyPair extends LDKeyPair {
         const {publicKey, privateKey} = await generateKeyPairAsync('ed25519', {
           publicKeyEncoding, privateKeyEncoding
         });
-        const publicKeyDerBytes = Buffer.from(publicKeyFromDer(publicKey));
+        const publicKeyBytes = publicKeyFromAsn1(
+          asn1.fromDer(new ByteBuffer(publicKey)));
+        const {privateKeyBytes} = privateKeyFromAsn1(
+          asn1.fromDer(new ByteBuffer(privateKey)));
+
         return new Ed25519KeyPair({
-          publicKeyBase58: bs58.encode(publicKeyDerBytes),
+          publicKeyBase58: bs58.encode(publicKeyBytes),
           // private key is the 32 byte private key + 32 byte public key
-          privateKeyBase58: bs58.encode(Buffer.concat([
-            privateKeyFromDer(privateKey),
-            publicKeyDerBytes
-          ])),
+          privateKeyBase58: bs58.encode(Buffer.concat(
+            [privateKeyBytes, publicKeyBytes])),
           ...options
         });
       }
@@ -121,16 +126,16 @@ class Ed25519KeyPair extends LDKeyPair {
       const publicKey = createPublicKey(privateKey);
 
       // export the keys and extract key bytes from the exported DERs
-      const publicKeyDerBytes = Buffer.from(publicKeyFromDer(
-        publicKey.export(publicKeyEncoding)));
-      const privateKeyDerBytes = Buffer.from(privateKeyFromDer(
-        privateKey.export(privateKeyEncoding)));
+      const publicKeyBytes = publicKeyFromAsn1(
+        asn1.fromDer(new ByteBuffer(publicKey.export(publicKeyEncoding))));
+      const {privateKeyBytes} = privateKeyFromAsn1(
+        asn1.fromDer(new ByteBuffer(privateKey.export(privateKeyEncoding))));
 
       return new Ed25519KeyPair({
-        publicKeyBase58: bs58.encode(publicKeyDerBytes),
+        publicKeyBase58: bs58.encode(publicKeyBytes),
         // private key is the 32 byte private key + 32 byte public key
         privateKeyBase58: bs58.encode(Buffer.concat(
-          [privateKeyDerBytes, publicKeyDerBytes])),
+          [privateKeyBytes, publicKeyBytes])),
         ...options
       });
     }

--- a/lib/Ed25519KeyPair.js
+++ b/lib/Ed25519KeyPair.js
@@ -78,7 +78,6 @@ class Ed25519KeyPair extends LDKeyPair {
    * @returns {Promise<Ed25519KeyPair>} Generates a key pair.
    */
   static async generate(options = {}) {
-    // FIXME: determine exact release that included ed25519 key generation
     if(env.nodejs && require('semver').gte(process.version, '12.0.0')) {
       const bs58 = require('bs58');
       const {
@@ -451,7 +450,6 @@ function ed25519SignerFactory(key) {
     };
   }
 
-  // FIXME: determine exact release that included ed25519 signing
   if(env.nodejs && require('semver').gte(process.version, '12.0.0')) {
     const bs58 = require('bs58');
     const privateKeyBytes = util.base58Decode({
@@ -521,7 +519,6 @@ function ed25519SignerFactory(key) {
  * to the key passed in.
  */
 function ed25519VerifierFactory(key) {
-  // FIXME: determine exact release that included ed25519 verification
   if(env.nodejs && require('semver').gte(process.version, '12.0.0')) {
     const bs58 = require('bs58');
     const publicKeyBytes = util.base58Decode({

--- a/lib/Ed25519KeyPair.js
+++ b/lib/Ed25519KeyPair.js
@@ -78,6 +78,62 @@ class Ed25519KeyPair extends LDKeyPair {
    * @returns {Promise<Ed25519KeyPair>} Generates a key pair.
    */
   static async generate(options = {}) {
+    // FIXME: determine exact release that included ed25519 key generation
+    if(env.nodejs && require('semver').gte(process.version, '12.0.0')) {
+      const bs58 = require('bs58');
+      const {ed25519: {privateKeyFromDer, publicKeyFromDer}} = forge;
+      const {promisify} = require('util');
+      const {createPublicKey, generateKeyPair} = require('crypto');
+      const publicKeyEncoding = {format: 'der', type: 'spki'};
+      const privateKeyEncoding = {format: 'der', type: 'pkcs8'};
+      // if no seed provided, generate a random key
+      if(!('seed' in options)) {
+        const generateKeyPairAsync = promisify(generateKeyPair);
+        const {publicKey, privateKey} = await generateKeyPairAsync('ed25519', {
+          publicKeyEncoding, privateKeyEncoding
+        });
+        const publicKeyDerBytes = Buffer.from(publicKeyFromDer(publicKey));
+        return new Ed25519KeyPair({
+          publicKeyBase58: bs58.encode(publicKeyDerBytes),
+          // private key is the 32 byte private key + 32 byte public key
+          privateKeyBase58: bs58.encode(Buffer.concat([
+            privateKeyFromDer(privateKey),
+            publicKeyDerBytes
+          ])),
+          ...options
+        });
+      }
+      // create a key from the provided seed
+      const {seed} = options;
+      let seedBytes;
+      if(seed instanceof Uint8Array || Buffer.isBuffer(seed)) {
+        seedBytes = Buffer.from(seed);
+      }
+      if(!(Buffer.isBuffer(seedBytes) && seedBytes.length === 32)) {
+        throw new TypeError('`seed` must be a 32 byte Buffer or Uint8Array.');
+      }
+      const _privateKey = require('./ed25519PrivateKeyNode12');
+
+      // create a node private key
+      const privateKey = _privateKey.create({seedBytes});
+
+      // create a node public key from the private key
+      const publicKey = createPublicKey(privateKey);
+
+      // export the keys and extract key bytes from the exported DERs
+      const publicKeyDerBytes = Buffer.from(publicKeyFromDer(
+        publicKey.export(publicKeyEncoding)));
+      const privateKeyDerBytes = Buffer.from(privateKeyFromDer(
+        privateKey.export(privateKeyEncoding)));
+
+      return new Ed25519KeyPair({
+        publicKeyBase58: bs58.encode(publicKeyDerBytes),
+        // private key is the 32 byte private key + 32 byte public key
+        privateKeyBase58: bs58.encode(Buffer.concat(
+          [privateKeyDerBytes, publicKeyDerBytes])),
+        ...options
+      });
+    }
     if(env.nodejs) {
       // TODO: use native node crypto api once it's available
       const sodium = require('sodium-native');
@@ -390,6 +446,29 @@ function ed25519SignerFactory(key) {
     };
   }
 
+  // FIXME: determine exact release that included ed25519 signing
+  if(env.nodejs && require('semver').gte(process.version, '12.0.0')) {
+    const bs58 = require('bs58');
+    const privateKeyBytes = util.base58Decode({
+      decode: bs58.decode,
+      keyMaterial: key.privateKeyBase58,
+      type: 'private'
+    });
+
+    const _privateKey = require('./ed25519PrivateKeyNode12');
+    // create a Node private key
+    const privateKey = _privateKey.create({privateKeyBytes});
+    const {sign} = require('crypto');
+
+    return {
+      async sign({data}) {
+        const signature = sign(
+          null, Buffer.from(data.buffer, data.byteOffset, data.length),
+          privateKey);
+        return signature;
+      }
+    };
+  }
   if(env.nodejs) {
     const sodium = require('sodium-native');
     const bs58 = require('bs58');
@@ -437,6 +516,26 @@ function ed25519SignerFactory(key) {
  * to the key passed in.
  */
 function ed25519VerifierFactory(key) {
+  // FIXME: determine exact release that included ed25519 verification
+  if(env.nodejs && require('semver').gte(process.version, '12.0.0')) {
+    const bs58 = require('bs58');
+    const publicKeyBytes = util.base58Decode({
+      decode: bs58.decode,
+      keyMaterial: key.publicKeyBase58,
+      type: 'public'
+    });
+    const _publicKey = require('./ed25519PublicKeyNode12');
+    // create a Node public key
+    const publicKey = _publicKey.create({publicKeyBytes});
+    const {verify} = require('crypto');
+    return {
+      async verify({data, signature}) {
+        return verify(
+          null, Buffer.from(data.buffer, data.byteOffset, data.length),
+          publicKey, signature);
+      }
+    };
+  }
   if(env.nodejs) {
     const sodium = require('sodium-native');
     const bs58 = require('bs58');

--- a/lib/ed25519PrivateKeyNode12.js
+++ b/lib/ed25519PrivateKeyNode12.js
@@ -1,0 +1,69 @@
+/*!
+ * Copyright (c) 2019 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const {asn1, oids, util: {ByteBuffer}} = require('node-forge');
+const {createPrivateKey} = require('crypto');
+
+exports.create = ({privateKeyBytes, seedBytes}) => createPrivateKey({
+  key: exports._derEncode({privateKeyBytes, seedBytes}),
+  format: 'der',
+  type: 'pkcs8'
+});
+
+// exported for testing
+exports._derEncode = ({privateKeyBytes, seedBytes}) => {
+  if(!(privateKeyBytes || seedBytes)) {
+    throw new TypeError('`privateKeyBytes` or `seedBytes` is required.');
+  }
+  if(!privateKeyBytes && !(Buffer.isBuffer(seedBytes) &&
+    seedBytes.length === 32)) {
+    throw new TypeError('`seedBytes` must be a 32 byte Buffer.');
+  }
+  if(!seedBytes && !(Buffer.isBuffer(privateKeyBytes) &&
+    privateKeyBytes.length === 64)) {
+    throw new TypeError('`privateKeyBytes` must be a 64 byte Buffer.');
+  }
+  let p;
+  if(seedBytes) {
+    p = seedBytes;
+  } else {
+    // extract the first 32 bytes of the 64 byte private key representation
+    p = Buffer.from(privateKeyBytes.buffer, privateKeyBytes.byteOffset, 32);
+  }
+  const keyBuffer = new ByteBuffer(p);
+
+  const asn1Key = asn1.create(
+    asn1.UNIVERSAL,
+    asn1.Type.OCTETSTRING,
+    false,
+    keyBuffer.getBytes()
+  );
+
+  const a = asn1.create(
+    asn1.Class.UNIVERSAL,
+    asn1.Type.SEQUENCE,
+    true, [
+      asn1.create(
+        asn1.Class.UNIVERSAL, asn1.Type.INTEGER, false,
+        asn1.integerToDer(0).getBytes()),
+      // privateKeyAlgorithm
+      asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, [
+        asn1.create(
+          asn1.Class.UNIVERSAL,
+          asn1.Type.OID,
+          false,
+          asn1.oidToDer(oids.EdDSA25519).getBytes()
+        ),
+      ]),
+      // private key
+      asn1.create(
+        asn1.Class.UNIVERSAL, asn1.Type.OCTETSTRING, false,
+        asn1.toDer(asn1Key).getBytes()),
+    ]
+  );
+
+  const privateKeyDer = asn1.toDer(a);
+  return Buffer.from(privateKeyDer.getBytes(), 'binary');
+};

--- a/lib/ed25519PrivateKeyNode12.js
+++ b/lib/ed25519PrivateKeyNode12.js
@@ -3,67 +3,11 @@
  */
 'use strict';
 
-const {asn1, oids, util: {ByteBuffer}} = require('node-forge');
 const {createPrivateKey} = require('crypto');
+const {privateKeyDerEncode} = require('./util');
 
 exports.create = ({privateKeyBytes, seedBytes}) => createPrivateKey({
-  key: exports._derEncode({privateKeyBytes, seedBytes}),
+  key: privateKeyDerEncode({privateKeyBytes, seedBytes}),
   format: 'der',
   type: 'pkcs8'
 });
-
-// exported for testing
-exports._derEncode = ({privateKeyBytes, seedBytes}) => {
-  if(!(privateKeyBytes || seedBytes)) {
-    throw new TypeError('`privateKeyBytes` or `seedBytes` is required.');
-  }
-  if(!privateKeyBytes && !(Buffer.isBuffer(seedBytes) &&
-    seedBytes.length === 32)) {
-    throw new TypeError('`seedBytes` must be a 32 byte Buffer.');
-  }
-  if(!seedBytes && !(Buffer.isBuffer(privateKeyBytes) &&
-    privateKeyBytes.length === 64)) {
-    throw new TypeError('`privateKeyBytes` must be a 64 byte Buffer.');
-  }
-  let p;
-  if(seedBytes) {
-    p = seedBytes;
-  } else {
-    // extract the first 32 bytes of the 64 byte private key representation
-    p = Buffer.from(privateKeyBytes.buffer, privateKeyBytes.byteOffset, 32);
-  }
-  const keyBuffer = new ByteBuffer(p);
-
-  const asn1Key = asn1.create(
-    asn1.UNIVERSAL,
-    asn1.Type.OCTETSTRING,
-    false,
-    keyBuffer.getBytes()
-  );
-
-  const a = asn1.create(
-    asn1.Class.UNIVERSAL,
-    asn1.Type.SEQUENCE,
-    true, [
-      asn1.create(
-        asn1.Class.UNIVERSAL, asn1.Type.INTEGER, false,
-        asn1.integerToDer(0).getBytes()),
-      // privateKeyAlgorithm
-      asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, [
-        asn1.create(
-          asn1.Class.UNIVERSAL,
-          asn1.Type.OID,
-          false,
-          asn1.oidToDer(oids.EdDSA25519).getBytes()
-        ),
-      ]),
-      // private key
-      asn1.create(
-        asn1.Class.UNIVERSAL, asn1.Type.OCTETSTRING, false,
-        asn1.toDer(asn1Key).getBytes()),
-    ]
-  );
-
-  const privateKeyDer = asn1.toDer(a);
-  return Buffer.from(privateKeyDer.getBytes(), 'binary');
-};

--- a/lib/ed25519PublicKeyNode12.js
+++ b/lib/ed25519PublicKeyNode12.js
@@ -18,8 +18,8 @@ exports._derEncode = ({publicKeyBytes}) => {
   }
   // add a zero byte to the front of the publicKeyBytes, this results in
   // the bitstring being 256 bits vs. 170 bits (without padding)
-  const zeroArray = new Uint8Array([0]);
-  const keyBuffer = new ByteBuffer(Buffer.concat([zeroArray, publicKeyBytes]));
+  const zeroBuffer = Buffer.from(new Uint8Array([0]));
+  const keyBuffer = new ByteBuffer(Buffer.concat([zeroBuffer, publicKeyBytes]));
 
   const a = asn1.create(
     asn1.Class.UNIVERSAL,

--- a/lib/ed25519PublicKeyNode12.js
+++ b/lib/ed25519PublicKeyNode12.js
@@ -1,0 +1,45 @@
+/*!
+ * Copyright (c) 2019 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const {asn1, oids, util: {ByteBuffer}} = require('node-forge');
+const {createPublicKey} = require('crypto');
+
+exports.create = ({publicKeyBytes}) => createPublicKey({
+  key: exports._derEncode({publicKeyBytes}),
+  format: 'der',
+  type: 'spki'
+});
+
+exports._derEncode = ({publicKeyBytes}) => {
+  if(!(Buffer.isBuffer(publicKeyBytes) && publicKeyBytes.length === 32)) {
+    throw new TypeError('`publicKeyBytes` must be a 32 byte Buffer.');
+  }
+  // add a zero byte to the front of the publicKeyBytes, this results in
+  // the bitstring being 256 bits vs. 170 bits (without padding)
+  const zeroArray = new Uint8Array([0]);
+  const keyBuffer = new ByteBuffer(Buffer.concat([zeroArray, publicKeyBytes]));
+
+  const a = asn1.create(
+    asn1.Class.UNIVERSAL,
+    asn1.Type.SEQUENCE,
+    true, [
+      asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, [
+        asn1.create(
+          asn1.Class.UNIVERSAL,
+          asn1.Type.OID,
+          false,
+          asn1.oidToDer(oids.EdDSA25519).getBytes()
+        ),
+      ]),
+      // public key
+      asn1.create(
+        asn1.Class.UNIVERSAL, asn1.Type.BITSTRING, false,
+        keyBuffer.getBytes()),
+    ]
+  );
+
+  const publicKeyDer = asn1.toDer(a);
+  return Buffer.from(publicKeyDer.getBytes(), 'binary');
+};

--- a/lib/ed25519PublicKeyNode12.js
+++ b/lib/ed25519PublicKeyNode12.js
@@ -3,43 +3,11 @@
  */
 'use strict';
 
-const {asn1, oids, util: {ByteBuffer}} = require('node-forge');
 const {createPublicKey} = require('crypto');
+const {publicKeyDerEncode} = require('./util');
 
 exports.create = ({publicKeyBytes}) => createPublicKey({
-  key: exports._derEncode({publicKeyBytes}),
+  key: publicKeyDerEncode({publicKeyBytes}),
   format: 'der',
   type: 'spki'
 });
-
-exports._derEncode = ({publicKeyBytes}) => {
-  if(!(Buffer.isBuffer(publicKeyBytes) && publicKeyBytes.length === 32)) {
-    throw new TypeError('`publicKeyBytes` must be a 32 byte Buffer.');
-  }
-  // add a zero byte to the front of the publicKeyBytes, this results in
-  // the bitstring being 256 bits vs. 170 bits (without padding)
-  const zeroBuffer = Buffer.from(new Uint8Array([0]));
-  const keyBuffer = new ByteBuffer(Buffer.concat([zeroBuffer, publicKeyBytes]));
-
-  const a = asn1.create(
-    asn1.Class.UNIVERSAL,
-    asn1.Type.SEQUENCE,
-    true, [
-      asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, [
-        asn1.create(
-          asn1.Class.UNIVERSAL,
-          asn1.Type.OID,
-          false,
-          asn1.oidToDer(oids.EdDSA25519).getBytes()
-        ),
-      ]),
-      // public key
-      asn1.create(
-        asn1.Class.UNIVERSAL, asn1.Type.BITSTRING, false,
-        keyBuffer.getBytes()),
-    ]
-  );
-
-  const publicKeyDer = asn1.toDer(a);
-  return Buffer.from(publicKeyDer.getBytes(), 'binary');
-};

--- a/lib/util.js
+++ b/lib/util.js
@@ -3,6 +3,8 @@
  */
 'use strict';
 
+const {asn1, oids, util: {ByteBuffer}} = require('node-forge');
+
 /**
  * Wraps Base58 decoding operations in
  * order to provide consistent error messages.
@@ -37,4 +39,91 @@ exports.base58Decode = ({decode, keyMaterial, type}) => {
     throw new TypeError(`The ${type} key material must be Base58 encoded.`);
   }
   return bytes;
+};
+
+exports.privateKeyDerEncode = ({privateKeyBytes, seedBytes}) => {
+  if(!(privateKeyBytes || seedBytes)) {
+    throw new TypeError('`privateKeyBytes` or `seedBytes` is required.');
+  }
+  if(!privateKeyBytes && !(Buffer.isBuffer(seedBytes) &&
+    seedBytes.length === 32)) {
+    throw new TypeError('`seedBytes` must be a 32 byte Buffer.');
+  }
+  if(!seedBytes && !(Buffer.isBuffer(privateKeyBytes) &&
+    privateKeyBytes.length === 64)) {
+    throw new TypeError('`privateKeyBytes` must be a 64 byte Buffer.');
+  }
+  let p;
+  if(seedBytes) {
+    p = seedBytes;
+  } else {
+    // extract the first 32 bytes of the 64 byte private key representation
+    p = Buffer.from(privateKeyBytes.buffer, privateKeyBytes.byteOffset, 32);
+  }
+  const keyBuffer = new ByteBuffer(p);
+
+  const asn1Key = asn1.create(
+    asn1.UNIVERSAL,
+    asn1.Type.OCTETSTRING,
+    false,
+    keyBuffer.getBytes()
+  );
+
+  const a = asn1.create(
+    asn1.Class.UNIVERSAL,
+    asn1.Type.SEQUENCE,
+    true, [
+      asn1.create(
+        asn1.Class.UNIVERSAL, asn1.Type.INTEGER, false,
+        asn1.integerToDer(0).getBytes()),
+      // privateKeyAlgorithm
+      asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, [
+        asn1.create(
+          asn1.Class.UNIVERSAL,
+          asn1.Type.OID,
+          false,
+          asn1.oidToDer(oids.EdDSA25519).getBytes()
+        ),
+      ]),
+      // private key
+      asn1.create(
+        asn1.Class.UNIVERSAL, asn1.Type.OCTETSTRING, false,
+        asn1.toDer(asn1Key).getBytes()),
+    ]
+  );
+
+  const privateKeyDer = asn1.toDer(a);
+  return Buffer.from(privateKeyDer.getBytes(), 'binary');
+};
+
+exports.publicKeyDerEncode = ({publicKeyBytes}) => {
+  if(!(Buffer.isBuffer(publicKeyBytes) && publicKeyBytes.length === 32)) {
+    throw new TypeError('`publicKeyBytes` must be a 32 byte Buffer.');
+  }
+  // add a zero byte to the front of the publicKeyBytes, this results in
+  // the bitstring being 256 bits vs. 170 bits (without padding)
+  const zeroBuffer = Buffer.from(new Uint8Array([0]));
+  const keyBuffer = new ByteBuffer(Buffer.concat([zeroBuffer, publicKeyBytes]));
+
+  const a = asn1.create(
+    asn1.Class.UNIVERSAL,
+    asn1.Type.SEQUENCE,
+    true, [
+      asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, [
+        asn1.create(
+          asn1.Class.UNIVERSAL,
+          asn1.Type.OID,
+          false,
+          asn1.oidToDer(oids.EdDSA25519).getBytes()
+        ),
+      ]),
+      // public key
+      asn1.create(
+        asn1.Class.UNIVERSAL, asn1.Type.BITSTRING, false,
+        keyBuffer.getBytes()),
+    ]
+  );
+
+  const publicKeyDer = asn1.toDer(a);
+  return Buffer.from(publicKeyDer.getBytes(), 'binary');
 };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "base64url-universal": "^1.0.1",
     "bs58": "^4.0.1",
-    "node-forge": "^0.8.0"
+    "node-forge": "digitalbazaar/forge#asn1-validator-node-ed25519",
+    "semver": "^6.2.0"
   },
   "optionalDependencies": {
     "sodium-native": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,10 @@
     "bs58": false,
     "crypto": false,
     "sodium-native": false,
-    "util": false
+    "util": false,
+    "semver": false,
+    "./lib/ed25519PublicKeyNode12.js": false,
+    "./lib/ed25519PrivateKeyNode12.js": false
   },
   "engines": {
     "node": ">=8.3.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "base64url-universal": "^1.0.1",
     "bs58": "^4.0.1",
-    "node-forge": "digitalbazaar/forge#asn1-validator-node-ed25519",
+    "node-forge": "~0.9.0",
     "semver": "^6.2.0"
   },
   "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
   "dependencies": {
     "base64url-universal": "^1.0.1",
     "bs58": "^4.0.1",
-    "node-forge": "^0.8.0",
+    "node-forge": "^0.8.0"
+  },
+  "optionalDependencies": {
     "sodium-native": "^2.3.0"
   },
   "devDependencies": {

--- a/tests/ed25519-key-der.spec.js
+++ b/tests/ed25519-key-der.spec.js
@@ -1,0 +1,73 @@
+/*!
+ * Copyright (c) 2018-2019 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const bs58 = require('bs58');
+const {_derEncode: privateDerEncode} =
+  require('../lib/ed25519PrivateKeyNode12');
+const {_derEncode: publicDerEncode} = require('../lib/ed25519PublicKeyNode12');
+const util = require('../lib/util');
+const mockKey = require('./mock-key');
+
+const targetPrivateDerBytesBase64 =
+  'MC4CAQAwBQYDK2VwBCIEICuAHzsgGqFh8BWmT1iucnc0w4mS5KfnfnaOtHG6yWuA';
+const targetPublicDerBytesBase64 =
+  'MCowBQYDK2VwAyEAvHZI57pFMs4OnJfkcp0QSotH9LbDT/6yRtYKt/ZpUpU=';
+
+const privateKeyBytes = util.base58Decode({
+  decode: bs58.decode,
+  keyMaterial: mockKey.privateKeyBase58,
+  type: 'private'
+});
+
+const publicKeyBytes = util.base58Decode({
+  decode: bs58.decode,
+  keyMaterial: mockKey.publicKeyBase58,
+  type: 'public'
+});
+
+describe('Ed25519 Keys', () => {
+  describe('Ed25519 Private Key', () => {
+    describe('DER encoding', () => {
+      it('works properly', async () => {
+        const forgeDer = privateDerEncode({privateKeyBytes});
+        const forgeDerBytesBase64 = Buffer.from(forgeDer).toString('base64');
+        forgeDerBytesBase64.should.equal(targetPrivateDerBytesBase64);
+      });
+    }); // end DER encoding
+  }); // end Ed25519 Private Key
+
+  describe('Ed25519 Public Key', () => {
+    describe('DER encoding', () => {
+      it('works properly', async () => {
+        const forgeDer = publicDerEncode({publicKeyBytes});
+        const forgeDerBytesBase64 = Buffer.from(forgeDer).toString('base64');
+        forgeDerBytesBase64.should.equal(targetPublicDerBytesBase64);
+      });
+    }); // end DER encoding
+  }); // end Ed25519 Private Key
+});
+
+// export DERs from Node public and private keys to use as test vectors
+/*
+async function _generateTestVector() {
+  const {createPublicKey} = require('crypto');
+  const _privateKey = require('../lib/ed25519PrivateKeyNode12');
+
+  // create a node private key
+  const privateKey = _privateKey.create({privateKeyBytes});
+
+  // create a node public key from the private key
+  const publicKey = createPublicKey(privateKey);
+
+  // export the keys and extract key bytes from the exported DERs
+  const publicKeyEncoding = {format: 'der', type: 'spki'};
+  const privateKeyEncoding = {format: 'der', type: 'pkcs8'};
+  const publicKeyDerBytes = Buffer.from(publicKey.export(publicKeyEncoding));
+  const privateKeyDerBytes = Buffer.from(privateKey.export(privateKeyEncoding));
+  publicKeyDerBytes.toString('base64').should.equal(targetPublicDerBytesBase64);
+  privateKeyDerBytes.toString('base64').should.equal(
+    targetPrivateDerBytesBase64);
+}
+*/

--- a/tests/ed25519-key-der.spec.js
+++ b/tests/ed25519-key-der.spec.js
@@ -3,7 +3,7 @@
  */
 'use strict';
 
-const bs58 = require('bs58');
+const {util: {binary: {base58}}} = require('node-forge');
 const {_derEncode: privateDerEncode} =
   require('../lib/ed25519PrivateKeyNode12');
 const {_derEncode: publicDerEncode} = require('../lib/ed25519PublicKeyNode12');
@@ -16,13 +16,13 @@ const targetPublicDerBytesBase64 =
   'MCowBQYDK2VwAyEAvHZI57pFMs4OnJfkcp0QSotH9LbDT/6yRtYKt/ZpUpU=';
 
 const privateKeyBytes = util.base58Decode({
-  decode: bs58.decode,
+  decode: base58.decode,
   keyMaterial: mockKey.privateKeyBase58,
   type: 'private'
 });
 
 const publicKeyBytes = util.base58Decode({
-  decode: bs58.decode,
+  decode: base58.decode,
   keyMaterial: mockKey.publicKeyBase58,
   type: 'public'
 });

--- a/tests/ed25519-key-der.spec.js
+++ b/tests/ed25519-key-der.spec.js
@@ -4,10 +4,8 @@
 'use strict';
 
 const {util: {binary: {base58}}} = require('node-forge');
-const {_derEncode: privateDerEncode} =
-  require('../lib/ed25519PrivateKeyNode12');
-const {_derEncode: publicDerEncode} = require('../lib/ed25519PublicKeyNode12');
-const util = require('../lib/util');
+const {base58Decode, privateKeyDerEncode, publicKeyDerEncode} =
+  require('../lib/util');
 const mockKey = require('./mock-key');
 
 const targetPrivateDerBytesBase64 =
@@ -15,13 +13,13 @@ const targetPrivateDerBytesBase64 =
 const targetPublicDerBytesBase64 =
   'MCowBQYDK2VwAyEAvHZI57pFMs4OnJfkcp0QSotH9LbDT/6yRtYKt/ZpUpU=';
 
-const privateKeyBytes = util.base58Decode({
+const privateKeyBytes = base58Decode({
   decode: base58.decode,
   keyMaterial: mockKey.privateKeyBase58,
   type: 'private'
 });
 
-const publicKeyBytes = util.base58Decode({
+const publicKeyBytes = base58Decode({
   decode: base58.decode,
   keyMaterial: mockKey.publicKeyBase58,
   type: 'public'
@@ -31,7 +29,7 @@ describe('Ed25519 Keys', () => {
   describe('Ed25519 Private Key', () => {
     describe('DER encoding', () => {
       it('works properly', async () => {
-        const forgeDer = privateDerEncode({privateKeyBytes});
+        const forgeDer = privateKeyDerEncode({privateKeyBytes});
         const forgeDerBytesBase64 = Buffer.from(forgeDer).toString('base64');
         forgeDerBytesBase64.should.equal(targetPrivateDerBytesBase64);
       });
@@ -41,7 +39,7 @@ describe('Ed25519 Keys', () => {
   describe('Ed25519 Public Key', () => {
     describe('DER encoding', () => {
       it('works properly', async () => {
-        const forgeDer = publicDerEncode({publicKeyBytes});
+        const forgeDer = publicKeyDerEncode({publicKeyBytes});
         const forgeDerBytesBase64 = Buffer.from(forgeDer).toString('base64');
         forgeDerBytesBase64.should.equal(targetPublicDerBytesBase64);
       });

--- a/tests/ld-key-pair.spec.js
+++ b/tests/ld-key-pair.spec.js
@@ -1,3 +1,6 @@
+/*!
+ * Copyright (c) 2018-2019 Digital Bazaar, Inc. All rights reserved.
+ */
 'use strict';
 
 const chai = require('chai');
@@ -33,6 +36,22 @@ describe('LDKeyPair', () => {
     });
 
     describe('generate', () => {
+      it('should generate a key pair', async () => {
+        let ldKeyPair;
+        let error;
+        try {
+          ldKeyPair = await LDKeyPair.generate({type});
+        } catch(e) {
+          error = e;
+        }
+        should.not.exist(error);
+        should.exist(ldKeyPair.privateKeyBase58);
+        should.exist(ldKeyPair.publicKeyBase58);
+        const privateKeyBytes = base58.decode(ldKeyPair.privateKeyBase58);
+        const publicKeyBytes = base58.decode(ldKeyPair.publicKeyBase58);
+        privateKeyBytes.length.should.equal(64);
+        publicKeyBytes.length.should.equal(32);
+      });
       it('should generate the same key from the same seed', async () => {
         const seed = new Uint8Array(32);
         seed.fill(0x01);
@@ -52,6 +71,15 @@ describe('LDKeyPair', () => {
         expect(error).to.exist;
       });
     });
+
+    describe('signer factory', () => {
+      it('should create a signer', async () => {
+        const ldKeyPair = await LDKeyPair.generate({type});
+        const signer = ldKeyPair.signer();
+        should.exist(signer.sign);
+        signer.sign.should.be.a('function');
+      });
+    }); // end signer factor
 
     describe('fingerprint', () => {
       it('should create an Ed25519 key fingerprint', async () => {
@@ -151,7 +179,7 @@ describe('LDKeyPair', () => {
         expect(result.error).to.exist;
         result.error.message.should.contain('must be Base58 encoded');
       });
-      it('should generate the same fingerprint from the same seed', async () => {
+      it('generates the same fingerprint from the same seed', async () => {
         const seed = new Uint8Array(32);
         seed.fill(0x01);
         const keyPair1 = await Ed25519KeyPair.generate({seed});

--- a/tests/mock-key.json
+++ b/tests/mock-key.json
@@ -1,0 +1,6 @@
+{
+  "id": "#test-id",
+  "type": "Ed25519VerificationKey2018",
+  "publicKeyBase58": "DggG1kT5JEFwTC6RJTsT6VQPgCz1qszCkX5Lv4nun98x",
+  "privateKeyBase58": "sSicNq6YBSzafzYDAcuduRmdHtnrZRJ7CbvjzdQhC45ewwvQeuqbM2dNwS9RCf6buUJGu6N3rBy6oLSpMwha8tc"
+}

--- a/tests/sign-verify.spec.js
+++ b/tests/sign-verify.spec.js
@@ -1,0 +1,37 @@
+/*!
+ * Copyright (c) 2018-2019 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const {Ed25519KeyPair} = require('..');
+const mockKey = require('./mock-key');
+
+const keyPair = new Ed25519KeyPair({
+  publicKeyBase58: mockKey.publicKeyBase58,
+  privateKeyBase58: mockKey.privateKeyBase58
+});
+
+const signer = keyPair.signer();
+const verifier = keyPair.verifier();
+
+// the same signature should be generated on every test platform
+// (eg. browser, node8, node12)
+const targetSignatureBase64 = 'nlQC1bVF6TMN6cAEJllRGK5orHm5+n4Ih46mu' +
+  'RYgQhTl8J9SR82fEPq7IEAmT9GprBrcRKJzxUk0Eo+yU92zCg==';
+
+describe('sign and verify', () => {
+  it('works properly', async () => {
+    const data = Buffer.from('test 1234');
+    const signature = await signer.sign({data});
+    signature.toString('base64').should.equal(targetSignatureBase64);
+    const result = await verifier.verify({data, signature});
+    result.should.be.true;
+  });
+  it('fails if signing data is changed', async () => {
+    const data = Buffer.from('test 1234');
+    const signature = await signer.sign({data});
+    const changedData = Buffer.from('test 4321');
+    const result = await verifier.verify({data: changedData, signature});
+    result.should.be.false;
+  });
+});


### PR DESCRIPTION
sodium-native becomes an optional dependency.  Unless someone specifies `npm install --no-optional`, sodium-native will still attempt to build and fail on node 12.  If there's a better way, please advise.

I've tested this myself on node12 and node10.  Travis seems to be failing because it's not recognizing that `digitalbazaar/forge#asn1-validator-node-ed25519` has been rebased.  It's not seeing the OID, being referenced in this code.  Possibly Travis is incorrectly using a cached copy of node-forge?

This does depend on: https://github.com/digitalbazaar/forge/pull/680

I'll point out that the jsonld-signatures branch that utilizes this code is now passing for all the node versions!  https://travis-ci.org/digitalbazaar/jsonld-signatures/builds/560087401