### PR TITLE
Implement fromFingerprint().

### DIFF
--- a/lib/LDKeyPair.js
+++ b/lib/LDKeyPair.js
@@ -4,6 +4,7 @@
 'use strict';
 
 const forge = require('node-forge');
+const {util: {binary: {base58}}} = forge;
 
 class LDKeyPair {
   /**
@@ -114,6 +115,31 @@ class LDKeyPair {
         throw new Error(`Unsupported Key Type: ${options.type}`);
     }
   }
+
+  /**
+   * Creates an instance of LDKeyPair from a key fingerprint.
+   * Note: Only key types that use their full public key in the fingerprint
+   * are supported (so, currently, only 'ed25519').
+   *
+   * @param {string} fingerprint
+   * @returns {LDKeyPair}
+   * @throws Unsupported Fingerprint Type.
+   */
+  static fromFingerprint({fingerprint}) {
+    // skip leading `z` that indicates base58 encoding
+    const buffer = base58.decode(fingerprint.substr(1));
+
+    // buffer is: 0xed 0x01 <public key bytes>
+    if(buffer[0] === 0xed && buffer[1] === 0x01) {
+      const Ed25519KeyPair = require('./Ed25519KeyPair');
+      return new Ed25519KeyPair({
+        publicKeyBase58: base58.encode(buffer.slice(2))
+      });
+    }
+
+    throw new Error(`Unsupported Fingerprint Type: ${fingerprint}`);
+  }
+
   /**
    * Generates a
    * [pdkdf2]{@link https://en.wikipedia.org/wiki/PBKDF2} key.

--- a/tests/ld-key-pair.spec.js
+++ b/tests/ld-key-pair.spec.js
@@ -167,6 +167,16 @@ describe('LDKeyPair', () => {
       });
     });
 
+    describe('static fromFingerprint', () => {
+      it('should round-trip load keys', async () => {
+        const keyPair = await Ed25519KeyPair.generate();
+        const fingerprint = keyPair.fingerprint();
+
+        const newKey = LDKeyPair.fromFingerprint({fingerprint});
+        expect(newKey.publicKeyBase58).to.equal(keyPair.publicKeyBase58);
+      });
+    });
+
     /* eslint-disable max-len */
     describe('static from', () => {
       it('should round-trip load exported keys', async () => {


### PR DESCRIPTION
(for use with `did:key` driver)

Simplistic implementation of issue #16 (only handles `ed25519` type keys).