### PR TITLE
Auto-init key.id based on controller, if present.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # crypto-ld ChangeLog
 
+## 4.0.0 - TBD
+
+### Added
+- Auto-initialize key.id based on controller (if it's present).
+
+### Changed
+- **BREAKING**: Explicitly make `publicBase58` property required for Ed25519
+  type keys (throw error if missing).
+
 ## 3.7.0 - 2019-09-06
 
 ### Added

--- a/lib/Ed25519KeyPair.js
+++ b/lib/Ed25519KeyPair.js
@@ -41,7 +41,7 @@ class Ed25519KeyPair extends LDKeyPair {
     this.type = 'Ed25519VerificationKey2018';
     this.publicKeyBase58 = options.publicKeyBase58;
     if(!this.publicKeyBase58) {
-      throw TypeError('The "publicKeyBase58" property is required.');
+      throw new TypeError('The "publicKeyBase58" property is required.');
     }
     this.privateKeyBase58 = options.privateKeyBase58;
     if(this.controller && !this.id) {

--- a/lib/Ed25519KeyPair.js
+++ b/lib/Ed25519KeyPair.js
@@ -28,21 +28,23 @@ class Ed25519KeyPair extends LDKeyPair {
    * > const EDKey = new Ed25519KeyPair(options);
    * > EDKey
    * Ed25519KeyPair { ...
-   * @param {KeyPairOptions} options - Base58 keys plus
-   * other options most follow
+   * @param {KeyPairOptions} options - Options hashmap.
    * [KeyPairOptions]{@link ./index.md#KeyPairOptions}.
    * @param {string} options.publicKeyBase58 - Base58 encoded Public Key
-   * unencoded is 32-bytes.
-   * @param {string} options.privateKeyBase58 - Base58 Private Key
-   * unencoded is 64-bytes.
+   *   (unencoded is 32-bytes).
+   * @param {string} [options.privateKeyBase58] - Base58 Private Key
+   *   (unencoded is 64-bytes).
    */
   /* eslint-enable */
   constructor(options = {}) {
     super(options);
     this.type = 'Ed25519VerificationKey2018';
-    this.privateKeyBase58 = options.privateKeyBase58;
     this.publicKeyBase58 = options.publicKeyBase58;
-    if(this.controller && this.publicKeyBase58 && !this.id) {
+    if(!this.publicKeyBase58) {
+      throw TypeError('The "publicKeyBase58" property is required.');
+    }
+    this.privateKeyBase58 = options.privateKeyBase58;
+    if(this.controller && !this.id) {
       this.id = `${this.controller}#${this.fingerprint()}`;
     }
   }

--- a/lib/Ed25519KeyPair.js
+++ b/lib/Ed25519KeyPair.js
@@ -42,6 +42,9 @@ class Ed25519KeyPair extends LDKeyPair {
     this.type = 'Ed25519VerificationKey2018';
     this.privateKeyBase58 = options.privateKeyBase58;
     this.publicKeyBase58 = options.publicKeyBase58;
+    if(this.controller && this.publicKeyBase58 && !this.id) {
+      this.id = `${this.controller}#${this.fingerprint()}`;
+    }
   }
   /**
    * Returns the Base58 encoded public key.

--- a/lib/RSAKeyPair.js
+++ b/lib/RSAKeyPair.js
@@ -50,8 +50,10 @@ class RSAKeyPair extends LDKeyPair {
     this.type = 'RsaVerificationKey2018';
     this.privateKeyPem = options.privateKeyPem;
     this.publicKeyPem = options.publicKeyPem;
-
     this.validateKeyParams(); // validate keyBits and exponent
+    if(this.controller && this.publicKeyPem && !this.id) {
+      this.id = `${this.controller}#${this.fingerprint()}`;
+    }
   }
   /**
    * Returns the public key.

--- a/tests/ld-key-pair.spec.js
+++ b/tests/ld-key-pair.spec.js
@@ -40,7 +40,7 @@ describe('LDKeyPair', () => {
         } catch(e) {
           error = e;
         }
-        expect(error.name).to.equal('TypeError');
+        expect(error).to.be.an.instanceof(TypeError);
         expect(error.message)
           .to.equal('The "publicKeyBase58" property is required.');
       });

--- a/tests/ld-key-pair.spec.js
+++ b/tests/ld-key-pair.spec.js
@@ -40,6 +40,7 @@ describe('LDKeyPair', () => {
         } catch(e) {
           error = e;
         }
+        expect(error.name).to.equal('TypeError');
         expect(error.message)
           .to.equal('The "publicKeyBase58" property is required.');
       });

--- a/tests/ld-key-pair.spec.js
+++ b/tests/ld-key-pair.spec.js
@@ -9,6 +9,7 @@ const {
   pki: {getPublicKeyFingerprint, publicKeyFromPem},
   util: {binary: {base58}}
 } = require('node-forge');
+const mockKey = require('./mock-key.json');
 const multibase = require('multibase');
 const multicodec = require('multicodec');
 const multihashes = require('multihashes');
@@ -21,6 +22,17 @@ const {LDKeyPair, Ed25519KeyPair, RSAKeyPair} = require('..');
 describe('LDKeyPair', () => {
   describe('Ed25519KeyPair', () => {
     const type = 'Ed25519VerificationKey2018';
+
+    describe('constructor', () => {
+      it('should auto-set key.id based on controller, if present', async () => {
+        const {publicKeyBase58} = mockKey;
+        const controller = 'did:example:1234';
+
+        const keyPair = new Ed25519KeyPair({controller, publicKeyBase58});
+        expect(keyPair.id).to.equal(
+          'did:example:1234#z6Mks8wJbzhWdmkQZgw7z2qHwaxPVnFsFmEZSXzGkLkvhMvL');
+      });
+    });
 
     describe('export', () => {
       it('should export id, type and key material', async () => {

--- a/tests/ld-key-pair.spec.js
+++ b/tests/ld-key-pair.spec.js
@@ -32,6 +32,17 @@ describe('LDKeyPair', () => {
         expect(keyPair.id).to.equal(
           'did:example:1234#z6Mks8wJbzhWdmkQZgw7z2qHwaxPVnFsFmEZSXzGkLkvhMvL');
       });
+
+      it('should error if publicKeyBase58 property is missing', async () => {
+        let error;
+        try {
+          new Ed25519KeyPair({});
+        } catch(e) {
+          error = e;
+        }
+        expect(error.message)
+          .to.equal('The "publicKeyBase58" property is required.');
+      });
     });
 
     describe('export', () => {


### PR DESCRIPTION
If a `controller` is passed to the LDKeyPair constructor, this PR initializes the key id based on our controller + fingerprint recommendations.