### PR TITLE
Use sodium-native@3.2.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "semver": "^6.2.0"
   },
   "optionalDependencies": {
-    "sodium-native": "^2.3.0"
+    "sodium-native": "^3.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",


### PR DESCRIPTION
sodium-native@3 uses NAPI and therefore builds on various node versions are no longer required.  YAY!