### PR TITLE
Break key class into LDPublicKey and LDKeyPair.

### DIFF
--- a/lib/LDKeyPair.js
+++ b/lib/LDKeyPair.js
@@ -3,6 +3,8 @@
  */
 'use strict';
 
+const {LDPublicKey} = require('./LDPublicKey');
+
 /**
  * When adding support for a new suite type for `crypto-ld`, developers should
  * do the following:
@@ -12,7 +14,7 @@
  *    LDKeyPair (for all other types, such as key-agreement-related).
  * 3. Add to the key type table in the `crypto-ld` README.md (that's this repo).
  */
-class LDKeyPair {
+class LDKeyPair extends LDPublicKey {
   /**
    * Creates a public/private key pair instance. This is an abstract base class,
    * actual key material and suite-specific methods are handled in the subclass.
@@ -23,12 +25,10 @@ class LDKeyPair {
    * @param {string} id - The Key id, typically composed of controller
    *   URL and key fingerprint as hash fragment.
    * @param {string} controller - DID/URL of the person/entity
-   *   controlling this key.
+   *   controlling this key pair.
    */
   constructor({id, controller} = {}) {
-    this.id = id;
-    this.controller = controller;
-    // this.type is set in subclass constructor
+    super({id, controller});
   }
 
   /**
@@ -49,14 +49,8 @@ class LDKeyPair {
    * Generates a KeyPair from some options.
    * @param {object} options  - Will generate a key pair
    * in multiple different formats.
-   * @example
-   * > const options = {
-   *    type: 'Ed25519VerificationKey2018'
-   *   };
-   * > const edKeyPair = await LDKeyPair.from(options);
    *
-   * @returns {Promise<LDKeyPair>} A LDKeyPair.
-   * @throws Unsupported Key Type.
+   * @returns {Promise<LDKeyPair>} A key pair.
    */
   static async from(/* options */) {
     throw new Error('Abstract method, must be implemented in subclass.');
@@ -92,16 +86,6 @@ class LDKeyPair {
   }
 
   /**
-   * Adds the suite-specific public key material, serialized to string, to
-   * the exported public key node.
-   * @param {object} key - Public key object.
-   * @returns {object}
-   */
-  addPublicKey(/* {key} */) {
-    throw new Error('Abstract method, must be implemented in subclass.');
-  }
-
-  /**
    * Adds the suite-specific private key material, serialized to string, to
    * the exported public key node.
    *
@@ -109,33 +93,6 @@ class LDKeyPair {
    * @returns {object}
    */
   addPrivateKey(/* {key} */) {
-    throw new Error('Abstract method, must be implemented in subclass.');
-  }
-
-  /**
-   * Returns the public key fingerprint, multibase+multicodec encoded. The
-   * specific fingerprint method is determined by the key suite, and is often
-   * either a hash of the public key material (such as with RSA), or the
-   * full encoded public key (for key types with sufficiently short
-   * representations, such as ed25519).
-   * This is frequently used in initializing the key id, or generating some
-   * types of cryptonym DIDs.
-   *
-   * @returns {string}
-   */
-  fingerprint() {
-    throw new Error('Abstract method, must be implemented in subclass.');
-  }
-
-  /**
-   * Verifies that a given key fingerprint matches the public key material
-   * belonging to this key pair.
-   *
-   * @param {string} fingerprint - Public key fingerprint.
-   *
-   * @returns {{verified: boolean}}
-   */
-  verifyFingerprint(/* {fingerprint} */) {
     throw new Error('Abstract method, must be implemented in subclass.');
   }
 }

--- a/lib/LDPublicKey.js
+++ b/lib/LDPublicKey.js
@@ -1,0 +1,117 @@
+/*!
+ * Copyright (c) 2021 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+/**
+ * When adding support for a new suite type for `crypto-ld`, developers should
+ * do the following:
+ *
+ * 1. Create their own npm package / github repo, such as
+ *    `example-verification-key-2020`.
+ * 2. Subclass either LDVerifierPublicKey (for signature-related suites), or
+ *    LDPublicKey (for all other types, such as key-agreement-related).
+ * 3. Add to the key type table in the `crypto-ld` README.md (that's this repo).
+ */
+class LDPublicKey {
+  /**
+   * Creates a public key instance. This is an abstract base class,
+   * actual key material and suite-specific methods are handled in the subclass.
+   *
+   * To generate or import a key, use the `cryptoLd` instance.
+   * @see CryptoLD.js
+   *
+   * @param {string} id - The Key id, typically composed of controller
+   *   URL and public key fingerprint as hash fragment.
+   * @param {string} controller - DID/URL of the person/entity
+   *   controlling this key.
+   */
+  constructor({id, controller} = {}) {
+    this.id = id;
+    this.controller = controller;
+    // this.type is set in subclass constructor
+  }
+
+  /**
+   * Generates a new public key instance.
+   * Note that this method is not typically called directly by client code,
+   * but instead is used through a `cryptoLd` instance.
+   *
+   * @param {object} options - Suite-specific options for this key. For
+   *   common options, see the `LDPublicKey.constructor()` docstring.
+   *
+   * @returns {Promise<LDPublicKey>} A public key instance.
+   */
+  static async generate(/* options */) {
+    throw new Error('Abstract method, must be implemented in subclass.');
+  }
+
+  /**
+   * Generates a key instance from some options.
+   *
+   * @param {object} options - Key options (subclass-specific).
+   *
+   * @returns {Promise<LDPublicKey>} A new public key instance.
+   */
+  static async from(/* options */) {
+    throw new Error('Abstract method, must be implemented in subclass.');
+  }
+
+  /**
+   * Exports the serialized representation of the key
+   * and other information that json-ld Signatures can use to verify a proof.
+   *
+   * @returns {object} A public key object
+   *   information used in verification methods by signatures.
+   */
+  export() {
+    const key = {
+      id: this.id,
+      type: this.type,
+      controller: this.controller
+    };
+    this.addPublicKey({key}); // Subclass-specific
+    return key;
+  }
+
+  /**
+   * Adds the suite-specific public key material, serialized to string, to
+   * the exported public key node.
+   * @param {object} key - Public key object.
+   * @returns {object}
+   */
+  addPublicKey(/* {key} */) {
+    throw new Error('Abstract method, must be implemented in subclass.');
+  }
+
+  /**
+   * Returns the public key fingerprint, multibase+multicodec encoded. The
+   * specific fingerprint method is determined by the key suite, and is often
+   * either a hash of the public key material (such as with RSA), or the
+   * full encoded public key (for key types with sufficiently short
+   * representations, such as ed25519).
+   * This is frequently used in initializing the key id, or generating some
+   * types of cryptonym DIDs.
+   *
+   * @returns {string}
+   */
+  fingerprint() {
+    throw new Error('Abstract method, must be implemented in subclass.');
+  }
+
+  /**
+   * Verifies that a given key fingerprint matches the public key material
+   * belonging to this key.
+   *
+   * @param {string} fingerprint - Public key fingerprint.
+   *
+   * @returns {{verified: boolean}}
+   */
+  verifyFingerprint(/* {fingerprint} */) {
+    throw new Error('Abstract method, must be implemented in subclass.');
+  }
+}
+
+module.exports = {
+  LDPublicKey
+};

--- a/lib/LDPublicKey.js
+++ b/lib/LDPublicKey.js
@@ -33,20 +33,6 @@ class LDPublicKey {
   }
 
   /**
-   * Generates a new public key instance.
-   * Note that this method is not typically called directly by client code,
-   * but instead is used through a `cryptoLd` instance.
-   *
-   * @param {object} options - Suite-specific options for this key. For
-   *   common options, see the `LDPublicKey.constructor()` docstring.
-   *
-   * @returns {Promise<LDPublicKey>} A public key instance.
-   */
-  static async generate(/* options */) {
-    throw new Error('Abstract method, must be implemented in subclass.');
-  }
-
-  /**
    * Generates a key instance from some options.
    *
    * @param {object} options - Key options (subclass-specific).
@@ -70,7 +56,7 @@ class LDPublicKey {
       type: this.type,
       controller: this.controller
     };
-    this.addPublicKey({key}); // Subclass-specific
+    this.exportPublicKeyMaterial({key}); // Subclass-specific
     return key;
   }
 
@@ -80,7 +66,7 @@ class LDPublicKey {
    * @param {object} key - Public key object.
    * @returns {object}
    */
-  addPublicKey(/* {key} */) {
+  exportPublicKeyMaterial(/* {key} */) {
     throw new Error('Abstract method, must be implemented in subclass.');
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,14 +1,16 @@
 /*
- * Copyright (c) 2018-2020 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2018-2021 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 
 const {CryptoLD} = require('./CryptoLD');
+const {LDPublicKey} = require('./LDPublicKey');
 const {LDKeyPair} = require('./LDKeyPair');
 const {LDVerifierKeyPair} = require('./LDVerifierKeyPair');
 
 module.exports = {
   CryptoLD,
+  LDPublicKey,
   LDKeyPair,
   LDVerifierKeyPair
 };

--- a/tests/unit/LDPublicKey.spec.js
+++ b/tests/unit/LDPublicKey.spec.js
@@ -1,0 +1,94 @@
+/*!
+ * Copyright (c) 2021 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const chai = require('chai');
+chai.should();
+const {expect} = chai;
+
+const {LDPublicKey} = require('../../lib');
+
+describe('LDPublicKey', () => {
+  let publicKey;
+  beforeEach(() => {
+    publicKey = new LDPublicKey();
+  });
+
+  describe('constructor', () => {
+    it('should initialize id and controller', async () => {
+      const controller = 'did:ex:1234';
+      const id = 'did:ex:1234#fingerprint';
+      const publicKey = new LDPublicKey({id, controller});
+
+      expect(publicKey.id).to.equal(id);
+      expect(publicKey.controller).to.equal(controller);
+    });
+  });
+
+  describe('generate()', () => {
+    it('should throw an abstract method error', async () => {
+      let error;
+
+      try {
+        await LDPublicKey.generate();
+      } catch(e) {
+        error = e;
+      }
+      expect(error.message).to.match(/Abstract method/);
+    });
+  });
+
+  describe('from()', () => {
+    it('should throw an abstract method error', async () => {
+      let error;
+
+      try {
+        await LDPublicKey.from();
+      } catch(e) {
+        error = e;
+      }
+      expect(error.message).to.match(/Abstract method/);
+    });
+  });
+
+  describe('addPublicKey()', () => {
+    it('should throw an abstract method error', async () => {
+      expect(() => publicKey.addPublicKey()).to.throw(/Abstract method/);
+    });
+  });
+
+  describe('fingerprint()', () => {
+    it('should throw an abstract method error', async () => {
+      expect(() => publicKey.fingerprint()).to.throw(/Abstract method/);
+    });
+  });
+
+  describe('verifyFingerprint()', () => {
+    it('should throw an abstract method error', async () => {
+      expect(() => publicKey.verifyFingerprint('z1234'))
+        .to.throw(/Abstract method/);
+    });
+  });
+
+  describe('export()', () => {
+    it('should export just the public key serialization', async () => {
+      publicKey.controller = 'did:ex:1234';
+      publicKey.id = 'did:ex:1234#fingerprint';
+      publicKey.type = 'ExampleVerificationKey2020';
+      const encodedPublicKey = 'encoded public key';
+
+      publicKey.addPublicKey = ({key}) => {
+        key.publicKeyMultibase = encodedPublicKey;
+        return key;
+      };
+
+      expect(publicKey.export({publicKey: true})).to.eql({
+        controller: 'did:ex:1234',
+        id: 'did:ex:1234#fingerprint',
+        publicKeyMultibase: 'encoded public key',
+        type: 'ExampleVerificationKey2020'
+      });
+    });
+  });
+});


### PR DESCRIPTION
Proposed refactoring, added to address @dlongley's comment https://github.com/digitalbazaar/did-method-key-js/pull/34/files#r563328517 about naming variables `keyPair` when you're only talking about a public key is confusing.

Currently (`<= v4.0`), only the KeyPair class exists, and when you're dealing with only a public key, you have a KeyPair instance that only has public key material. As Dave pointed out, that makes it somewhat awkward for variable and function parameter naming, so this PR attempts to make it more explicit.