### PR TITLE
Refactor cryptoLd driver to use fromKeyDocument.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # crypto-ld ChangeLog
 
+## 6.0.0 -
+
+### Changed
+- **BREAKING**: `.from()` now routs to `.fromKeyDocument()` if the serialized
+  key object has a `@context`. This update is to make for more secure behavior
+  when creating key pair instances from "untrusted" key objects (say, fetched
+  from the web etc).
+
 ## 5.1.0 - 2021-04-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -90,13 +90,13 @@ To use the library with one or more supported suites:
 
 ```js
 import {Ed25519VerificationKey2020} from '@digitalbazaar/ed25519-verification-key-2020';
-import {X25519KeyAgreementKey2019} from '@digitalbazaar/x25519-key-agreement-key-2019';
+import {X25519KeyAgreementKey2020} from '@digitalbazaar/x25519-key-agreement-key-2020';
 
 import {CryptoLD} from 'crypto-ld';
 const cryptoLd = new CryptoLD();
 
 cryptoLd.use(Ed25519VerificationKey2020);
-cryptoLd.use(X25519KeyAgreementKey2019);
+cryptoLd.use(X25519KeyAgreementKey2020);
 
 const edKeyPair = await cryptoLd.generate({type: 'Ed25519VerificationKey2020'});
 ```

--- a/lib/CryptoLD.js
+++ b/lib/CryptoLD.js
@@ -26,23 +26,18 @@ class CryptoLD {
   /**
    * Generates a public/private LDKeyPair.
    *
-   * @param {string} type - Key suite id ('Ed25519VerificationKey2020').
-   *
-   * @param {object} [options] - Optional suite-specific key options.
+   * @param {object} options - Suite-specific key options.
+   * @param {string} options.type - Key suite id (for example,
+   *   'Ed25519VerificationKey2020').
    * @param {string} [options.controller] - Controller DID or URL for the
    *   generated key pair. If present, used to auto-initialize the key.id.
    *
    * @returns {Promise<LDKeyPair>}
    */
-  async generate({type, ...options} = {}) {
-    if(!type) {
-      throw new TypeError('A key type is required to generate.');
-    }
-    if(!this._installed({type})) {
-      throw new TypeError(`Support for key type "${type}" is not installed.`);
-    }
+  async generate(options = {}) {
+    const Suite = this._suiteForType(options);
 
-    return this.suites.get(type).generate(options);
+    return Suite.generate(options);
   }
 
   /**
@@ -55,16 +50,42 @@ class CryptoLD {
    * @returns {Promise<LDKeyPair>}
    */
   async from(serialized = {}) {
-    const type = serialized && serialized.type;
+    const Suite = this._suiteForType(serialized);
 
-    if(!type) {
-      throw new TypeError('Missing key type.');
-    }
-    if(!this._installed({type})) {
-      throw new Error(`Support for key type "${type}" is not installed.`);
+    if(serialized['@context']) {
+      // This is an untrusted (fetched, etc) key document
+      return Suite.fromKeyDocument({document: serialized});
     }
 
-    return this.suites.get(type).from(serialized);
+    return Suite.from(serialized);
+  }
+
+  /**
+   * Imports a key pair instance from a provided externally fetched key
+   * document (fetched via a secure JSON-LD `documentLoader` or via
+   * `cryptoLd.fromKeyId()`), optionally checking it for revocation and required
+   * context.
+   *
+   * @param {object} options - Options hashmap.
+   * @param {string} options.document - Externally fetched key document.
+   * @param {boolean} [options.checkContext=true] - Whether to check that the
+   *   fetched key document contains the context required by the key's crypto
+   *   suite.
+   * @param {boolean} [options.checkRevoked=true] - Whether to check the key
+   *   object for the presence of the `revoked` timestamp.
+   *
+   * @returns {Promise<LDKeyPair>} Resolves with the resulting key pair
+   *   instance.
+   */
+  async fromKeyDocument({
+    document, checkContext = true, checkRevoked = true
+  } = {}) {
+    if(!document) {
+      throw new TypeError('The "document" parameter is required.');
+    }
+    const Suite = this._suiteForType(document);
+
+    return Suite.fromKeyDocument({document, checkContext, checkRevoked});
   }
 
   /**
@@ -126,6 +147,28 @@ class CryptoLD {
    */
   _installed({type}) {
     return this.suites.has(type);
+  }
+
+  /**
+   * Returns the installed crypto suite class for a given document's type.
+   *
+   * @param {object} document - A serialized key document (or options document).
+   * @param {string} document.type - Key suite id (for example,
+   *   'Ed25519VerificationKey2020').
+   *
+   * @returns {object} LDKeyPair (crypto suite) class.
+   */
+  _suiteForType(document) {
+    const type = document && document.type;
+
+    if(!type) {
+      throw new TypeError('Missing key type.');
+    }
+    if(!this._installed({type})) {
+      throw new Error(`Support for key type "${type}" is not installed.`);
+    }
+
+    return this.suites.get(type);
   }
 }
 

--- a/lib/CryptoLD.js
+++ b/lib/CryptoLD.js
@@ -52,7 +52,7 @@ class CryptoLD {
     const Suite = this._suiteForType(serialized);
 
     if(serialized['@context']) {
-      // This is an untrusted (fetched, etc) key document
+      // presume this may be an untrusted (fetched, etc) key document
       return Suite.fromKeyDocument({document: serialized});
     }
 

--- a/lib/CryptoLD.js
+++ b/lib/CryptoLD.js
@@ -36,7 +36,6 @@ class CryptoLD {
    */
   async generate(options = {}) {
     const Suite = this._suiteForType(options);
-
     return Suite.generate(options);
   }
 

--- a/tests/unit/CryptoLD.spec.js
+++ b/tests/unit/CryptoLD.spec.js
@@ -44,7 +44,7 @@ describe('CryptoLD', () => {
         error = e;
       }
       expect(error.message).to
-        .equal('A key type is required to generate.');
+        .equal('Missing key type.');
     });
 
     it('should error on unsupported type', async () => {
@@ -59,15 +59,17 @@ describe('CryptoLD', () => {
     });
 
     it('should generate based on key type', async () => {
-      const keyLibrary = {
+      const Suite = {
         suite: 'Ed25519VerificationKey2018',
         generate: async options => options
       };
-      cryptoLd.use(keyLibrary);
+      cryptoLd.use(Suite);
       const result = await cryptoLd.generate({
         type: 'Ed25519VerificationKey2018', controller: 'did:ex:1234'
       });
-      expect(result).to.eql({controller: 'did:ex:1234'});
+      expect(result).to.eql({
+        controller: 'did:ex:1234', type: 'Ed25519VerificationKey2018'
+      });
     });
   });
 
@@ -96,11 +98,11 @@ describe('CryptoLD', () => {
     });
 
     it('should return an instance from serialized data', async () => {
-      const keyLibrary = {
+      const Suite = {
         suite: 'Ed25519VerificationKey2018',
         from: async data => data
       };
-      cryptoLd.use(keyLibrary);
+      cryptoLd.use(Suite);
 
       const serializedKey = {
         type: 'Ed25519VerificationKey2018'


### PR DESCRIPTION
Also, `cryptoLd.from()` now routes to `fromKeyDocument` on "untrusted" key objects (ones that contain a `@context`).